### PR TITLE
BCReco: Increase error level to ignore errors from integration again

### DIFF
--- a/source/BeamCalReco/include/BCRootUtilities.hh
+++ b/source/BeamCalReco/include/BCRootUtilities.hh
@@ -6,6 +6,8 @@
 class TFile;
 class BeamCalGeo;
 
+#include <TError.h>
+
 #include <string>
 #include <vector>
 
@@ -18,6 +20,19 @@ namespace BCUtil{
 		     std::string energyField="sEdep",
 		     bool isFromMokka = false
 		     );
+
+
+  class IgnoreRootError {
+  public:
+    IgnoreRootError(bool enable=true): orgErrorLevel(gErrorIgnoreLevel) {
+      if( enable ) { gErrorIgnoreLevel=kError+1; }
+    }
+    ~IgnoreRootError(){
+      gErrorIgnoreLevel=orgErrorLevel;
+    }
+  private:
+    int orgErrorLevel;
+  };
 
 }//end namespace
 

--- a/source/BeamCalReco/src/BeamCalBkgParam.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgParam.cpp
@@ -126,10 +126,7 @@ void BeamCalBkgParam::init(vector<string> &bg_files, const int n_bx)
 
 void BeamCalBkgParam::getEventBG(BCPadEnergies &peLeft, BCPadEnergies &peRight)
 {
-  const int originalErrorLevel = gErrorIgnoreLevel;
-  if( not streamlog::out.write< streamlog::DEBUG0 >() ) {
-    gErrorIgnoreLevel=kError;
-  }
+  BCUtil::IgnoreRootError ire( not streamlog::out.write< streamlog::DEBUG0 >() );
 
   const int nBCpads = m_BCG->getPadsPerBeamCal();
   vector<double> vedep(nBCpads, 0.);
@@ -181,8 +178,6 @@ void BeamCalBkgParam::getEventBG(BCPadEnergies &peLeft, BCPadEnergies &peRight)
   streamlog_out(DEBUG) << "BeamCalBkgParam: total energy generated with parametrised method for "
 		       << "Left and Right BeamCal = " << peLeft.getTotalEnergy() << "\t" 
 		       << peRight.getTotalEnergy() << std::endl;
-
-  gErrorIgnoreLevel=originalErrorLevel;
 
 }
 
@@ -285,14 +280,10 @@ double gausOverX(double *x, double* p) {
 
 int BeamCalBkgParam::setBkgDistr(const BCPadEnergies::BeamCalSide_t bc_side)
 {
+  //this in highest debug level only
+  BCUtil::IgnoreRootError ire( not streamlog::out.write< streamlog::DEBUG0 >() );
 
   streamlog_out( MESSAGE0 ) << "Creating Background Distributions: " << bc_side << std::endl;
-
-  const int originalErrorLevel = gErrorIgnoreLevel;
-  //this in highest debug level only
-  if( not streamlog::out.write< streamlog::DEBUG0 >() ) {
-    gErrorIgnoreLevel=kError;
-  }
 
   const int nBCpads = m_BCG->getPadsPerBeamCal();
   vector<TF1*> &vunr = (BCPadEnergies::kLeft == bc_side ? m_unuransLeft : m_unuransRight);
@@ -330,9 +321,6 @@ int BeamCalBkgParam::setBkgDistr(const BCPadEnergies::BeamCalSide_t bc_side)
       }
     }
   }
-
-
-  gErrorIgnoreLevel=originalErrorLevel;
 
   return 0;
 }

--- a/source/BeamCalReco/src/BeamCalFitShower.cpp
+++ b/source/BeamCalReco/src/BeamCalFitShower.cpp
@@ -10,12 +10,12 @@
 #include "BeamCalFitShower.hh"
 #include "BeamCalPadGeometry.hh"
 #include "BeamCalGeoCached.hh"
+#include "BCRootUtilities.hh"
 
 // ROOT
 #include "TMath.h"
 #include "Minuit2/Minuit2Minimizer.h"
 #include "Math/Functor.h"
-#include "TError.h"
 
 #include <algorithm>
 #include <iomanip>
@@ -81,9 +81,8 @@ BeamCalFitShower::operator=(const BeamCalFitShower&fs)
 
 double BeamCalFitShower::fitShower(double &theta, double &phi, double &en_shwr, double &chi2)
 {
+  BCUtil::IgnoreRootError ire();
 
-  const int originalErrorLevel = gErrorIgnoreLevel;
-  gErrorIgnoreLevel=kError;
   // select spot pads around most likely shower
   m_spotPads.clear();
   vector<int> pad_list;
@@ -201,7 +200,6 @@ double BeamCalFitShower::fitShower(double &theta, double &phi, double &en_shwr, 
 
   // calculate probability that this is our shower
   double prob = TMath::Prob(chi2, m_spotPads.size());
-  gErrorIgnoreLevel=originalErrorLevel;
   return prob;
 }
 


### PR DESCRIPTION
Probably in root6 there is an additional error, or the error level
changed. Increase ignore level by 1 so errors are ignored (again).

Create object to hold original error level and restore error level at
destruction