### PR TITLE
LumiCalReco: parameters are now a shared_ptr

### DIFF
--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -152,8 +152,7 @@ int GlobalMethodsClass::CellIdZPR(int cellId, GlobalMethodsClass::Coordinate_t Z
 void GlobalMethodsClass::SetConstants( marlin::Processor* procPTR ) {
 
   
-  marlin::StringParameters* _lcalRecoPars = NULL;
-  _lcalRecoPars = procPTR->parameters();
+  std::shared_ptr<marlin::StringParameters> _lcalRecoPars = procPTR->parameters();
 
   //SetGeometryConstants
   if( SetGeometryDD4HEP() ) {


### PR DESCRIPTION
Depends on ilcsoft/Marlin#16

BEGINRELEASENOTES
- LumiCalReco: parameters are now a shared_ptr

ENDRELEASENOTES