### PR TITLE
LumiCalClusterer: wrap decoder object in unique_ptr to guarantee cleanup

### DIFF
--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace EVENT {
@@ -122,7 +123,7 @@ protected:
   MapIntInt    _numHitsInArm;
   //  VInt _armsToCluster;
 
-  CellIDDecoder<SimCalorimeterHit> * _mydecoder;
+  std::unique_ptr<CellIDDecoder<SimCalorimeterHit>> _mydecoder{};
 
   GlobalMethodsClass _gmc;
   bool _useDD4hep;

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -51,7 +51,7 @@ LumiCalClustererClass::LumiCalClustererClass(std::string const& lumiNameNow):
   _minSeparationDistance(), _minClusterEngyGeV(), _minClusterEngySignal(),
   _totEngyArm(),
   _numHitsInArm(),
-  _mydecoder(NULL),
+  _mydecoder(),
   _gmc(),
   _useDD4hep(false),
   RotMat()

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -41,7 +41,7 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
 #endif
 
     if (not _mydecoder) {
-      _mydecoder = new CellIDDecoder<SimCalorimeterHit> (col);
+      _mydecoder = std::unique_ptr< CellIDDecoder<SimCalorimeterHit> >( new CellIDDecoder<SimCalorimeterHit>(col) );
     }
     const int nHitsCol = col->getNumberOfElements();
     if ( nHitsCol < _clusterMinNumHits ) return 0;


### PR DESCRIPTION

BEGINRELEASENOTES
- LumiCalClusterer: wrap decoder object in unique_ptr to guarantee cleanup, fixes memory leak

ENDRELEASENOTES