### PR TITLE
LumiCalClusterer: clean calHits also if there are not enough

### DIFF
--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -283,6 +283,8 @@ protected:
 
   void dumpClusters( MapIntLCCluster const& clusterCM );
 
+  void cleanCalHits( MapIntMapIntVCalHit & calHits );
+
 };
 
 #endif // LumiCalClusterer_h

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -280,20 +280,23 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
 
 
   // cleanUp
-  for (std::map<int, std::map < int, std::vector <IMPL::CalorimeterHitImpl*> > >::iterator it = calHits.begin(); it != calHits.end(); ++it) {
-    std::map < int, std::vector <IMPL::CalorimeterHitImpl*> >& mapVecHits = it->second;
-    for (std::map < int, std::vector <IMPL::CalorimeterHitImpl*> >::iterator it2 = mapVecHits.begin(); it2 != mapVecHits.end(); ++it2) {
-      std::vector <IMPL::CalorimeterHitImpl*>& vecHits = it2->second;
-      for (std::vector<IMPL::CalorimeterHitImpl*>::iterator it3 = vecHits.begin(); it3 != vecHits.end(); ++it3) {
-	delete (*it3);
-      }
-    }
-  }
-
-  calHits.clear();
+  cleanCalHits( calHits );
   superClusterCM.clear();
   calHitsCellIdGlobal.clear();
 
   return OK;
 
+}
+
+void LumiCalClustererClass::cleanCalHits( MapIntMapIntVCalHit & calHits ) {
+  for (MapIntMapIntVCalHit::iterator it = calHits.begin(); it != calHits.end(); ++it) {
+    MapIntVCalHit& mapVecHits = it->second;
+    for (MapIntVCalHit::iterator it2 = mapVecHits.begin(); it2 != mapVecHits.end(); ++it2) {
+      VecCalHit& vecHits = it2->second;
+      for (VecCalHit::iterator it3 = vecHits.begin(); it3 != vecHits.end(); ++it3) {
+	delete (*it3);
+      }
+    }
+  }
+  calHits.clear();
 }

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -168,7 +168,7 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
 
     if(    (( _numHitsInArm[-1] < _clusterMinNumHits) || (_totEngyArm[-1] < _minClusterEngySignal))
 	   && (( _numHitsInArm[ 1] < _clusterMinNumHits) || (_totEngyArm[ 1] < _minClusterEngySignal)) ){
-      calHits.clear();
+      cleanCalHits( calHits );
       return 0;
     }else{ return 1; }
 }


### PR DESCRIPTION

BEGINRELEASENOTES
- LumiCalClusterer: fix memory leak if there are not enough hits to attempt clustering

ENDRELEASENOTES