### PR TITLE
LumiCalClusterer: assign hits to cluster

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,92 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     125
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+JavaScriptQuotes: Leave
+...

--- a/.travis-ci.d/compile_and_test.sh
+++ b/.travis-ci.d/compile_and_test.sh
@@ -6,7 +6,7 @@ source $ILCSOFT/init_ilcsoft.sh
 cd /Package
 mkdir build
 cd build
-cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always" .. && \
-ninja && \
+cmake -GNinja -C $ILCSOFT/ILCSoft.cmake -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always -Werror" .. && \
+ninja -k0 && \
 ninja install && \
 ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,3 +63,11 @@ if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(Tests)
 endif(BUILD_TESTING)
+
+### FORMATTING ##############################################################
+# Set the source files to clang-format (FIXME: determine this better
+FILE(GLOB_RECURSE
+     CHECK_CXX_SOURCE_FILES
+     /source/ *.cc *.cpp *.h *.hh
+     )
+INCLUDE("cmake/clang-cpp-checks.cmake")

--- a/cmake/clang-cpp-checks.cmake
+++ b/cmake/clang-cpp-checks.cmake
@@ -1,0 +1,37 @@
+# Additional targets to perform clang-format/clang-tidy
+
+# Get all project files - FIXME: this should also use the list of generated targets
+IF(NOT CHECK_CXX_SOURCE_FILES)
+    MESSAGE(FATAL_ERROR "Variable CHECK_CXX_SOURCE_FILES not defined - set it to the list of files to auto-format")
+    RETURN()
+ENDIF()
+
+# Adding clang-format check and formatter if found
+FIND_PROGRAM(CLANG_FORMAT "clang-format")
+IF(CLANG_FORMAT)
+    ADD_CUSTOM_TARGET(
+        format
+        COMMAND
+        ${CLANG_FORMAT}
+        -i
+        -style=file
+        ${CHECK_CXX_SOURCE_FILES}
+        COMMENT "Auto formatting of all source files"
+    )
+
+    ADD_CUSTOM_TARGET(
+        check-format
+        COMMAND
+        ${CLANG_FORMAT}
+        -style=file
+        -output-replacements-xml
+        ${CHECK_CXX_SOURCE_FILES}
+        # print output
+        | tee ${CMAKE_BINARY_DIR}/check_format_file.txt | grep -c "replacement " |
+                tr -d "[:cntrl:]" && echo " replacements necessary"
+        # WARNING: fix to stop with error if there are problems
+        COMMAND ! grep -c "replacement "
+                  ${CMAKE_BINARY_DIR}/check_format_file.txt > /dev/null
+        COMMENT "Checking format compliance"
+    )
+ENDIF()

--- a/source/BeamCalReco/src/BeamCal.cpp
+++ b/source/BeamCalReco/src/BeamCal.cpp
@@ -326,7 +326,7 @@ void BeamCal::DrawPhiDistributions(TPad *pad, Int_t layer, Option_t* options){
     Double_t extents[6];
     this->m_BCG.getPadExtents(i, 1, extents);
     if( not (extents[0] > this->m_BCG.getCutout()) ){
-#warning "FixMe number of bins in drawphidistributions"
+#pragma message "FixMe number of bins in drawphidistributions"
       //calculate bins for the limited range
       const double degreesDeadAngle = m_BCG.getDeadAngle()*TMath::RadToDeg();
       double limitedBinSize =  (360.0-degreesDeadAngle) / double(m_BCG.getPadsInRing(i));

--- a/source/LumiCalReco/include/LCCluster.hh
+++ b/source/LumiCalReco/include/LCCluster.hh
@@ -2,6 +2,7 @@
 #define LCCluster_hh 1
 
 #include "GlobalMethodsClass.h"
+#include "LumiCalHit.hh"
 
 #include <cmath>
 #include <ostream>
@@ -13,9 +14,9 @@ class LCCluster
 
 public:
   LCCluster();
-  LCCluster( const VirtualCluster& vc );
+  explicit LCCluster( const VirtualCluster& vc );
   LCCluster( double energy, double x, double y, double z, double weight,
-	     GlobalMethodsClass::WeightingMethod_t method, double theta, double phi );
+	     GlobalMethodsClass::WeightingMethod_t method, double theta, double phi, VecCalHit const& caloHitVector);
 
   ~LCCluster(){}
 
@@ -43,8 +44,11 @@ public:
   inline void setPhi    (double p) { _phi = p; }
 
   void addToEnergy( double E) { _energy += E; }
+
   friend std::ostream& operator<<(std::ostream & o, const LCCluster& rhs);
 
+
+  inline VecCalHit const& getCaloHits() const { return _caloHits; }
 
 private:
 
@@ -54,6 +58,7 @@ private:
   double _energy, _weight;
   GlobalMethodsClass::WeightingMethod_t _method;
   double _theta, _phi;
+  VecCalHit _caloHits;
 
 };
 

--- a/source/LumiCalReco/include/LumiCalHit.hh
+++ b/source/LumiCalReco/include/LumiCalHit.hh
@@ -1,0 +1,63 @@
+#ifndef LUMICALHIT_HH
+#define LUMICALHIT_HH 1
+
+#include "ProjectionInfo.hh"
+
+#include <memory>
+#include <vector>
+
+#include <EVENT/CalorimeterHit.h>
+
+/** Class to hold position and energy information of CalorimeterHits in the LumiCal
+
+ * To use of projected hits, which derive from multiple CalorimeterHits this
+ * wrapper is necessary to assign the original CalorimeterHits to the created
+ * cluster
+ */
+
+class LumiCalHit {
+public:
+  LumiCalHit() {}
+  LumiCalHit(int cellIDProjection, ProjectionInfo const& projection)
+      : m_cellID0(cellIDProjection),
+        m_cellID1(projection.getCellIdHitZ()),
+        m_energy(projection.getEnergy()),
+        m_position{projection.getPosition()[0], projection.getPosition()[1], projection.getPosition()[2]},
+        m_caloHits(projection.getCaloHits()) {}
+
+  ~LumiCalHit() {}
+
+private:
+  int    m_cellID0     = 0;
+  int    m_cellID1     = 0;
+  double m_energy      = 0.0;
+  double m_position[3] = {0.0, 0.0, 0.0};
+  /// original CalorimeterHits (in the global coordinate system)
+  VecLCIOCalHit m_caloHits{};
+
+public:
+  void addHit(EVENT::CalorimeterHit* hit) { m_caloHits.insert(hit); }
+
+  auto getHits() const -> decltype(m_caloHits) const & { return (m_caloHits); }
+  auto beginHits() const -> decltype(m_caloHits.begin()) { return m_caloHits.begin(); }
+  auto endHits() const -> decltype(m_caloHits.end()) { return m_caloHits.end(); }
+
+  void setEnergy(double e) { m_energy = e; }
+  void setCellID0(int i) { m_cellID0 = i; }
+  void setCellID1(int i) { m_cellID1 = i; }
+  void setPosition(double const* pos) {
+    m_position[0] = pos[0];
+    m_position[1] = pos[1];
+    m_position[2] = pos[2];
+  }  //fixme memcopy??
+
+  double        getEnergy() const { return m_energy; }
+  int           getCellID0() const { return m_cellID0; }
+  int           getCellID1() const { return m_cellID1; }
+  const double* getPosition() const { return m_position; }
+};
+
+using CalHit    = std::shared_ptr<LumiCalHit>;
+using VecCalHit = std::vector<CalHit>;
+
+#endif  // LUMICALHIT_HH

--- a/source/LumiCalReco/include/MarlinLumiCalClusterer.h
+++ b/source/LumiCalReco/include/MarlinLumiCalClusterer.h
@@ -57,6 +57,7 @@ typedef std::map < int , std::vector<int> >  MapIntVInt;
 
     // Processor Parameters
     std::string	LumiInColName;
+    std::string LumiOutColName = "LumiCalHits";
     std::string LumiClusterColName;
     std::string LumiRecoParticleColName ;
     double _BeamCrossingAngle;

--- a/source/LumiCalReco/include/ProjectionInfo.hh
+++ b/source/LumiCalReco/include/ProjectionInfo.hh
@@ -1,23 +1,38 @@
 #ifndef ProjectionInfo_hh
 #define ProjectionInfo_hh 1
 
-namespace IMPL {
-  class CalorimeterHitImpl;
+#include <memory>
+#include <set>
+
+namespace EVENT{
+  class CalorimeterHit;
 }
+
+class LumiCalHit;
+
+using CalHit = std::shared_ptr<LumiCalHit>;
+using VecLCIOCalHit = std::set<EVENT::CalorimeterHit*>;
 
 class ProjectionInfo {
 
 public:
-  ProjectionInfo ();
-  ProjectionInfo ( IMPL::CalorimeterHitImpl const* calHit, int cellIdHitZ);
+  ProjectionInfo();
+  ProjectionInfo(CalHit const& calHit, int cellIdHitZ);
+
+  void addHit(CalHit const& calHit );
 
   const double* getPosition() const { return position; }
+  double getEnergy() const { return energy; }
+  int getCellIdHitZ() const { return cellIdHitZ; }
+  VecLCIOCalHit const& getCaloHits() const { return hits; }
 
+private:
   double energy;
   double position[3];
   int cellIdHitZ;
+  VecLCIOCalHit hits{};
+public:
   bool newObject;
-
 };
 
 

--- a/source/LumiCalReco/include/SortingFunctions.hh
+++ b/source/LumiCalReco/include/SortingFunctions.hh
@@ -1,10 +1,10 @@
 #ifndef SortingFunctions_hh
 #define SortingFunctions_hh 1
 
-#include <IMPL/CalorimeterHitImpl.h>
+#include "LumiCalHit.hh"
 
+#include <memory>
 #include <vector>
-
 
 /* =========================================================================
    Auxiliary functions
@@ -17,11 +17,11 @@
    sorting of clusterCM[id] (for a cluster with Id 'id') with respect to the cluster CM energy
    -------------------------------------------------------------------------- */
 //in descending order (highest energy is first)
-inline bool clusterCMEnergyCmpDesc( std::vector<double> a, std::vector<double> b ) {
+inline bool clusterCMEnergyCmpDesc(std::vector<double> const& a, std::vector<double> const& b) {
   return a[0] > b[0];
 }
 //in ascending order (lowest energy is first)
-inline bool clusterCMEnergyCmpAsc( std::vector<double> a, std::vector<double> b ) {
+inline bool clusterCMEnergyCmpAsc(std::vector<double> const& a, std::vector<double> const& b) {
   return a[0] < b[0];
 }
 
@@ -30,12 +30,12 @@ inline bool clusterCMEnergyCmpAsc( std::vector<double> a, std::vector<double> b 
    sorting of hits with respect to their energies
    -------------------------------------------------------------------------- */
 //in descending order (highest energy is first)
-inline bool HitEnergyCmpDesc( IMPL::CalorimeterHitImpl* a, IMPL::CalorimeterHitImpl* b ) {
+inline bool HitEnergyCmpDesc(CalHit const& a, CalHit const& b) {
   return a->getEnergy() > b->getEnergy();
 }
 
 //in ascending order (lowest energy is first)
-inline bool HitEnergyCmpAsc( IMPL::CalorimeterHitImpl* a, IMPL::CalorimeterHitImpl* b ) {
+inline bool HitEnergyCmpAsc(CalHit const& a, CalHit const& b ) {
   return a->getEnergy() < b->getEnergy();
 }
 
@@ -45,7 +45,7 @@ inline bool HitEnergyCmpAsc( IMPL::CalorimeterHitImpl* a, IMPL::CalorimeterHitIm
    -------------------------------------------------------------------------- */
 //in ascending order (shortest distance is first)
 template <int POS>
-inline bool HitDistanceCMCmpAsc(  std::vector<double> const&a, std::vector<double> const&b ) {
+inline bool HitDistanceCMCmpAsc(std::vector<double> const& a, std::vector<double> const& b) {
   return a[POS] < b[POS];
 }
 

--- a/source/LumiCalReco/include/SortingFunctions.hh
+++ b/source/LumiCalReco/include/SortingFunctions.hh
@@ -1,11 +1,6 @@
 #ifndef SortingFunctions_hh
 #define SortingFunctions_hh 1
 
-#include "LumiCalHit.hh"
-
-#include <memory>
-#include <vector>
-
 /* =========================================================================
    Auxiliary functions
    ----------------------------------------------------------------------------
@@ -17,11 +12,13 @@
    sorting of clusterCM[id] (for a cluster with Id 'id') with respect to the cluster CM energy
    -------------------------------------------------------------------------- */
 //in descending order (highest energy is first)
-inline bool clusterCMEnergyCmpDesc(std::vector<double> const& a, std::vector<double> const& b) {
+template<class T>
+inline bool clusterCMEnergyCmpDesc(T const& a, T const& b) {
   return a[0] > b[0];
 }
 //in ascending order (lowest energy is first)
-inline bool clusterCMEnergyCmpAsc(std::vector<double> const& a, std::vector<double> const& b) {
+template<class T>
+inline bool clusterCMEnergyCmpAsc(T const& a, T const& b) {
   return a[0] < b[0];
 }
 
@@ -30,12 +27,14 @@ inline bool clusterCMEnergyCmpAsc(std::vector<double> const& a, std::vector<doub
    sorting of hits with respect to their energies
    -------------------------------------------------------------------------- */
 //in descending order (highest energy is first)
-inline bool HitEnergyCmpDesc(CalHit const& a, CalHit const& b) {
+template<class T>
+inline bool HitEnergyCmpDesc(T const& a, T const& b) {
   return a->getEnergy() > b->getEnergy();
 }
 
 //in ascending order (lowest energy is first)
-inline bool HitEnergyCmpAsc(CalHit const& a, CalHit const& b ) {
+template<typename T>
+inline bool HitEnergyCmpAsc(T const& a, T const& b) {
   return a->getEnergy() < b->getEnergy();
 }
 
@@ -44,8 +43,8 @@ inline bool HitEnergyCmpAsc(CalHit const& a, CalHit const& b ) {
    sorting of hits with respect to their distance from the CM of their cluster
    -------------------------------------------------------------------------- */
 //in ascending order (shortest distance is first)
-template <int POS>
-inline bool HitDistanceCMCmpAsc(std::vector<double> const& a, std::vector<double> const& b) {
+template <class T, int POS>
+inline bool HitDistanceCMCmpAsc(T const& a, T const& b) {
   return a[POS] < b[POS];
 }
 

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -4,46 +4,27 @@
 #include <iostream>
 #include <iomanip>
 
+LCCluster::LCCluster()
+    : _position{0.0, 0.0, 0.0}, _energy(0.0), _weight(0.0), _method("LogMethod"), _theta(0.0), _phi(0.0), _caloHits{} {}
 
-LCCluster::LCCluster():
-  _position(),
-  _energy(0.0),
-  _weight(0.0),
-  _method("LogMethod"),
-  _theta(0.0),
-  _phi(0.0)
-{
-  _position[0]=0.0;
-  _position[1]=0.0;
-  _position[2]=0.0;
-}
-
-LCCluster::LCCluster( const VirtualCluster& vc ):
-  _position(),
-  _energy(0.0),
-  _weight(0.0),
-  _method("LogMethod"),
-  _theta(0.0),
-  _phi(0.0)
-{
-
-  _position[0]=vc.getX();
-  _position[1]=vc.getY();
-  _position[2]=vc.getZ();
-}
+LCCluster::LCCluster(const VirtualCluster& vc)
+    : _position{vc.getX(), vc.getY(), vc.getZ()},
+      _energy(0.0),
+      _weight(0.0),
+      _method("LogMethod"),
+      _theta(0.0),
+      _phi(0.0),
+      _caloHits{} {}
 
 LCCluster::LCCluster(double energy, double x, double y, double z, double weight,
-		     GlobalMethodsClass::WeightingMethod_t method, double theta, double phi):
-  _position(),
-  _energy(energy),
-  _weight(weight),
-  _method(method),
-  _theta(theta),
-  _phi(phi)
-{
-  _position[0]=x;
-  _position[1]=y;
-  _position[2]=z;
+                     GlobalMethodsClass::WeightingMethod_t method, double theta, double phi, VecCalHit const& caloHitVector)
+    : _position{x, y, z},
+      _energy(energy),
+      _weight(weight),
+      _method(method),
+      _theta(theta),
+      _phi(phi),
+      _caloHits(caloHitVector) {
   CalculatePhi();
 }
 
@@ -56,12 +37,14 @@ void LCCluster::clear() {
   _method = "";
   _theta = 0.0;
   _phi = 0.0;
+  _caloHits.clear();
 }
 
 std::ostream& operator<<(std::ostream & o, const LCCluster& rhs) {
   o << "  Energy "              << std::setw(10) << rhs._energy
     << "  Method "              << std::setw(4)  << rhs._method
     << "  Weight "              << std::setw(10) << rhs._weight
+    << "  N Calo Hits "         << std::setw(7) <<  rhs._caloHits.size()
     << "  pos(x,y,z) =  ( "
     << std::setw(10) << rhs._position[0] << " , "
     << std::setw(10) << rhs._position[1] << " , "

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -275,28 +275,6 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
     }
   }
 
-
-
-
-
-  // cleanUp
-  cleanCalHits( calHits );
-  superClusterCM.clear();
-  calHitsCellIdGlobal.clear();
-
   return OK;
 
-}
-
-void LumiCalClustererClass::cleanCalHits( MapIntMapIntVCalHit & calHits ) {
-  for (MapIntMapIntVCalHit::iterator it = calHits.begin(); it != calHits.end(); ++it) {
-    MapIntVCalHit& mapVecHits = it->second;
-    for (MapIntVCalHit::iterator it2 = mapVecHits.begin(); it2 != mapVecHits.end(); ++it2) {
-      VecCalHit& vecHits = it2->second;
-      for (VecCalHit::iterator it3 = vecHits.begin(); it3 != vecHits.end(); ++it3) {
-	delete (*it3);
-      }
-    }
-  }
-  calHits.clear();
 }

--- a/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
@@ -507,7 +507,7 @@ double LumiCalClustererClass::getMoliereRadius( MapIntCalHit const& calHitsCellI
   }
 
   // sort the std::vector of the cal hits according to distance from CM in ascending order (shortest distance is first)
-  std::sort (clusterHitsEngyPos.begin(), clusterHitsEngyPos.end(), HitDistanceCMCmpAsc<1> );
+  std::sort(clusterHitsEngyPos.begin(), clusterHitsEngyPos.end(), HitDistanceCMCmpAsc<VVDouble::value_type, 1>);
   double distanceCM(0.0), engyAroundCM(0.0);
   for( VVDouble::iterator energyIt = clusterHitsEngyPos.begin();
        energyIt != clusterHitsEngyPos.end();
@@ -552,7 +552,7 @@ double LumiCalClustererClass::getDistanceAroundCMWithEnergyPercent( LCCluster co
   }
 
   // sort the std::vector of the cal hits according to distance from CM in ascending order (shortest distance is first)
-  sort (clusterHitsEngyPos.begin(), clusterHitsEngyPos.end(), HitDistanceCMCmpAsc<1> );
+  sort(clusterHitsEngyPos.begin(), clusterHitsEngyPos.end(), HitDistanceCMCmpAsc<VVDouble::value_type, 1>);
 
   double engyAroundCM(0.0), distanceCM(0.0);
   for( VVDouble::iterator energyIt = clusterHitsEngyPos.begin();

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters.cpp
@@ -28,18 +28,14 @@ using LCHelper::distance2D;
    - SOME DESCRIPTION ......
    ============================================================================ */
 
-int LumiCalClustererClass::buildClusters( std::map < int , std::vector <IMPL::CalorimeterHitImpl*> > const& calHits,
-					  MapIntCalHit & calHitsCellIdGlobal,
-					  MapIntVInt & superClusterIdToCellId,
-					  MapIntVDouble & superClusterIdToCellEngy,
-					  MapIntLCCluster & superClusterCM,
-					  const int detectorArm) {
-
+int LumiCalClustererClass::buildClusters(MapIntVCalHit const& calHits, MapIntCalHit& calHitsCellIdGlobal,
+                                         MapIntVInt& superClusterIdToCellId, MapIntVDouble& superClusterIdToCellEngy,
+                                         MapIntLCCluster& superClusterCM, const int detectorArm) {
   int   maxEngyLayerN(-1);
   double maxEngyLayer;
   int numSuperClusters;
 
-  std::vector < std::map <int , IMPL::CalorimeterHitImpl* > > calHitsCellId(_maxLayerToAnalyse), calHitsSmallEngyCellId(_maxLayerToAnalyse);
+  VMapIntCalHit calHitsCellId(_maxLayerToAnalyse), calHitsSmallEngyCellId(_maxLayerToAnalyse);
 
   std::vector < std::map < int , int > >        cellIdToClusterId(_maxLayerToAnalyse+1);
 

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
@@ -27,12 +27,9 @@ using LCHelper::distance2D;
    - SOME DESCRIPTION ......
    ============================================================================ */
 
-int LumiCalClustererClass::initialClusterBuild(	std::map < int , IMPL::CalorimeterHitImpl* > const& calHitsCellId,
-						std::map < int , int > & cellIdToClusterId,
-						std::map < int , std::vector<int> > & clusterIdToCellId,
-						std::map < int , LCCluster > & clusterCM,
-						std::vector < int > const& controlVar  ) {
-
+int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId, MapIntInt& cellIdToClusterId,
+                                               MapIntVInt& clusterIdToCellId,
+                                               MapIntLCCluster& clusterCM, VInt const& controlVar) {
   /* --------------------------------------------------------------------------
      layer parameters
      -------------------------------------------------------------------------- */
@@ -107,10 +104,9 @@ int LumiCalClustererClass::initialClusterBuild(	std::map < int , IMPL::Calorimet
   std::map <int , std::vector <int> >	neighborsConectedToMe ;
 
   // copy hits in this layer to a cal hit std::vector
-  std::vector <IMPL::CalorimeterHitImpl*>	calHitsLayer ;
+  VecCalHit calHitsLayer;
 
-  std::map <int , IMPL::CalorimeterHitImpl* > :: const_iterator calHitsCellIdIterator= calHitsCellId.begin(),
-    calHitsEnd = calHitsCellId.end();
+  MapIntCalHit::const_iterator calHitsCellIdIterator = calHitsCellId.begin(), calHitsEnd = calHitsCellId.end();
   for(; calHitsCellIdIterator != calHitsEnd; ++calHitsCellIdIterator){
     const int cellIdHit = (int)(*calHitsCellIdIterator).first;
     calHitsLayer.push_back( calHitsCellIdIterator->second );
@@ -142,10 +138,9 @@ int LumiCalClustererClass::initialClusterBuild(	std::map < int , IMPL::Calorimet
       if(cellIdNeighbor == 0) continue;
       try {
 	// if the neighbor has a cal hit...
-	std::map <int , IMPL::CalorimeterHitImpl* > :: const_iterator neighborIt =
-	  calHitsCellId.find(cellIdNeighbor);
-	if( neighborIt != calHitsCellId.end() ) {
-	  IMPL::CalorimeterHitImpl* neighbor = neighborIt->second;
+        MapIntCalHit::const_iterator neighborIt = calHitsCellId.find(cellIdNeighbor);
+        if (neighborIt != calHitsCellId.end()) {
+          auto const& neighbor = neighborIt->second;
 
 	  //if(tmpFlag==1) cout << "neighbor " << cellIdNeighbor
 	  //	<< " " << neighborIndex <<endl;
@@ -587,21 +582,19 @@ int LumiCalClustererClass::initialClusterBuild(	std::map < int , IMPL::Calorimet
    -     merge the unclustered cal hits with the existing clusters
    ============================================================================ */
 
-int LumiCalClustererClass::initialLowEngyClusterBuild( std::map < int , IMPL::CalorimeterHitImpl* > const& calHitsSmallEngyCellId,
-						       std::map < int , IMPL::CalorimeterHitImpl* >	& calHitsCellId,
-						       std::map < int , int >			& cellIdToClusterId,
-						       std::map < int , std::vector<int> >		& clusterIdToCellId,
-						       std::map < int , LCCluster > & clusterCM ) {
-
+int LumiCalClustererClass::initialLowEngyClusterBuild(MapIntCalHit const& calHitsSmallEngyCellId,
+                                                      MapIntCalHit& calHitsCellId, MapIntInt& cellIdToClusterId,
+                                                      MapIntVInt& clusterIdToCellId,
+                                                      MapIntLCCluster& clusterCM) {
   /* --------------------------------------------------------------------------
      merge the unclustered cal hits with the existing clusters
      -------------------------------------------------------------------------- */
-  std::map < int , IMPL::CalorimeterHitImpl* > :: const_iterator calHitsCellIdIterator = calHitsSmallEngyCellId.begin();
+  MapIntCalHit::const_iterator calHitsCellIdIterator = calHitsSmallEngyCellId.begin();
   for(; calHitsCellIdIterator != calHitsSmallEngyCellId.end(); ++calHitsCellIdIterator){
     const int cellIdHit = calHitsCellIdIterator->first;
 
     // add the small energy hits that have now been clustred to the cal hit list at calHitsCellId
-    IMPL::CalorimeterHitImpl* thisHit = calHitsCellIdIterator->second;
+    auto const& thisHit      = calHitsCellIdIterator->second;
     calHitsCellId[cellIdHit] = thisHit;
     // position of the cal hit
     double CM1[2] = { thisHit -> getPosition()[0], thisHit -> getPosition()[1]};
@@ -651,12 +644,10 @@ int LumiCalClustererClass::initialLowEngyClusterBuild( std::map < int , IMPL::Ca
    --------------------------------
    - SOME DESCRIPTION ......
    ============================================================================ */
-int LumiCalClustererClass::virtualCMClusterBuild( std::map < int , IMPL::CalorimeterHitImpl* >	const& calHitsCellId,
-						  std::map < int , int >			& cellIdToClusterId,
-						  std::map < int , std::vector<int> >		& clusterIdToCellId,
-						  std::map < int , LCCluster >	& clusterCM,
-						  std::map < int , VirtualCluster >	const& virtualClusterCM ) {
-
+int LumiCalClustererClass::virtualCMClusterBuild(MapIntCalHit const& calHitsCellId, MapIntInt& cellIdToClusterId,
+                                                 MapIntVInt& clusterIdToCellId,
+                                                 MapIntLCCluster& clusterCM,
+                                                 MapIntVirtualCluster const& virtualClusterCM) {
   std::vector < int > unClusteredCellId;
 
 #if _VIRTUALCLUSTER_BUILD_DEBUG == 1
@@ -666,10 +657,9 @@ int LumiCalClustererClass::virtualCMClusterBuild( std::map < int , IMPL::Calorim
   /* --------------------------------------------------------------------------
      form clusters by gathering hits inside the virtual cluster radius
      -------------------------------------------------------------------------- */
-  for( std::map < int , IMPL::CalorimeterHitImpl* > :: const_iterator calHitsCellIdIterator = calHitsCellId.begin();
+  for (MapIntCalHit::const_iterator calHitsCellIdIterator = calHitsCellId.begin();
        calHitsCellIdIterator != calHitsCellId.end(); ++calHitsCellIdIterator) {
-
-    const IMPL::CalorimeterHitImpl *thisHit = calHitsCellIdIterator->second;
+    const auto& thisHit = calHitsCellIdIterator->second;
     double CM1[2] = { thisHit->getPosition()[0], thisHit->getPosition()[1] };
 
     // compute the distance of the cal hit from the virtual cluster CMs, and keep score of
@@ -756,7 +746,7 @@ int LumiCalClustererClass::virtualCMClusterBuild( std::map < int , IMPL::Calorim
     std::map < int , double > weightedDistanceV;
 
     // position of the cal hit
-    const IMPL::CalorimeterHitImpl *thisHit = calHitsCellId.at(cellIdHit);
+    const auto& thisHit = calHitsCellId.at(cellIdHit);
     double CM1[2] = { thisHit->getPosition()[0], thisHit->getPosition()[1] };
 
     // compute weight for the cal hit and each cluster
@@ -795,12 +785,10 @@ int LumiCalClustererClass::virtualCMClusterBuild( std::map < int , IMPL::Calorim
    --------------------------------
    - SOME DESCRIPTION ......
    ============================================================================ */
-int LumiCalClustererClass::virtualCMPeakLayersFix( std::map < int , IMPL::CalorimeterHitImpl* > const& calHitsCellId,
-						   std::map < int , int > & cellIdToClusterId,
-						   std::map < int , std::vector<int> > & clusterIdToCellId,
-						   std::map < int , LCCluster > & clusterCM,
-						   std::map < int , VirtualCluster > virtualClusterCM ) {
-
+int LumiCalClustererClass::virtualCMPeakLayersFix(MapIntCalHit const& calHitsCellId, MapIntInt& cellIdToClusterId,
+                                                  MapIntVInt& clusterIdToCellId,
+                                                  MapIntLCCluster& clusterCM,
+                                                  MapIntVirtualCluster virtualClusterCM) {
   // general variables
   std::vector < std::vector <double> >	unClusteredCellId;
 
@@ -897,7 +885,7 @@ int LumiCalClustererClass::virtualCMPeakLayersFix( std::map < int , IMPL::Calori
     std::map < int , double > weightedDistanceV;
 
     // compute the distance of the cal hit from the virtual cluster CMs
-    const IMPL::CalorimeterHitImpl *thisHit = calHitsCellIdIterator->second;
+    const auto& thisHit = calHitsCellIdIterator->second;
 
     for(std::map < int , VirtualCluster > :: const_iterator virtualClusterCMIterator = virtualClusterCM.begin();
 	virtualClusterCMIterator != virtualClusterCM.end(); ++virtualClusterCMIterator ) {
@@ -973,17 +961,14 @@ int LumiCalClustererClass::virtualCMPeakLayersFix( std::map < int , IMPL::Calori
    - SOME DESCRIPTION ......
    ============================================================================ */
 
-int LumiCalClustererClass::buildSuperClusters ( std::map <int , IMPL::CalorimeterHitImpl* > & calHitsCellIdGlobal,
-						std::vector < std::map < int , IMPL::CalorimeterHitImpl* > > const& calHitsCellIdLayer,
-						std::vector < std::map < int , std::vector<int> > > const& clusterIdToCellId,
-						std::vector < std::map < int , LCCluster > > const& clusterCM,
-						std::vector < std::map < int , VirtualCluster > > const& virtualClusterCM,
-						std::map < int , int > & cellIdToSuperClusterId,
-						std::map < int , std::vector<int> > & superClusterIdToCellId,
-						std::map < int , LCCluster > & superClusterCM ) {
-
-
-  /* --------------------------------------------------------------------------
+int LumiCalClustererClass::buildSuperClusters(MapIntCalHit& calHitsCellIdGlobal, VMapIntCalHit const& calHitsCellIdLayer,
+                                              VMapIntVInt const& clusterIdToCellId,
+                                              VMapIntLCCluster const& clusterCM,
+                                              VMapIntVirtualCluster const& virtualClusterCM,
+                                              MapIntInt& cellIdToSuperClusterId,
+                                              MapIntVInt& superClusterIdToCellId,
+                                              MapIntLCCluster& superClusterCM) {
+/* --------------------------------------------------------------------------
      merge all layer-clusters into global superClusters according to distance
      from the virtual clusters' CM
      -------------------------------------------------------------------------- */
@@ -1084,7 +1069,7 @@ int LumiCalClustererClass::buildSuperClusters ( std::map <int , IMPL::Calorimete
 	std::map < int , double > weightedDistanceV;
 
 	// position of the cal hit
-	IMPL::CalorimeterHitImpl* thisHit = calHitsCellIdLayer.at(layerNow).at(cellIdHit);
+        const auto& thisHit = calHitsCellIdLayer.at(layerNow).at(cellIdHit);
 	double CM1[2] = { thisHit->getPosition()[0], thisHit->getPosition()[1] };
 
 #if _VIRTUALCLUSTER_BUILD_DEBUG == 1
@@ -1173,18 +1158,14 @@ int LumiCalClustererClass::buildSuperClusters ( std::map <int , IMPL::Calorimete
    --------------------------------
    - SOME DESCRIPTION ......
    ============================================================================ */
-int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHitsCellIdGlobal,
-                                                      std::map < int,std::vector <IMPL::CalorimeterHitImpl*> > const& calHits,
-                                                      std::vector < MapIntCalHit > const& ,//   calHitsCellIdLayer,
-                                                      std::vector < MapIntVInt > & clusterIdToCellId,
-                                                      std::vector < MapIntLCCluster > & clusterCM,
-                                                      std::vector < std::map < int , int > > & cellIdToClusterId,
-                                                      std::map < int , int > & cellIdToSuperClusterId,
-                                                      MapIntVInt & superClusterIdToCellId,
-                                                      MapIntLCCluster & superClusterCM,
-                                                      double middleEnergyHitBound,
-                                                      int /* detectorArm */ ) {
-
+int LumiCalClustererClass::engyInMoliereCorrections(MapIntCalHit const& calHitsCellIdGlobal, MapIntVCalHit const& calHits,
+                                                    VMapIntCalHit const&,  //   calHitsCellIdLayer,
+                                                    VMapIntVInt&      clusterIdToCellId,
+                                                    VMapIntLCCluster& clusterCM,
+                                                    VMapIntInt& cellIdToClusterId,
+                                                    MapIntInt& cellIdToSuperClusterId,
+                                                    MapIntVInt& superClusterIdToCellId, MapIntLCCluster& superClusterCM,
+                                                    double middleEnergyHitBound, int /* detectorArm */) {
   // ???????? DECIDE/FIX - incorparate the parameter given here better in the code ????????
   int    engyHitBoundMultiply = 1;
   double molRadPercentage     = 0.4;
@@ -1289,13 +1270,11 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
     /* --------------------------------------------------------------------------
        sum up the energy for each Phi/R cell for all Z layers
        -------------------------------------------------------------------------- */
-    std::map < int , std::vector <IMPL::CalorimeterHitImpl*> >::const_iterator calHitsIt = calHits.begin(),
-      calHitsEnd = calHits.end();
+    MapIntVCalHit::const_iterator calHitsIt = calHits.begin(), calHitsEnd = calHits.end();
     for (; calHitsIt != calHitsEnd; ++calHitsIt) {
-      std::pair < int , std::vector < IMPL::CalorimeterHitImpl*> > const& layerHits = (*calHitsIt);
-      const int numElementsInLayer = (int)layerHits.second.size();
+      const int numElementsInLayer = (int)calHitsIt->second.size();
       for(int j=0; j<numElementsInLayer; j++){
-	IMPL::CalorimeterHitImpl const* thisCalHit = layerHits.second.at(j);
+        const auto& thisCalHit = calHitsIt->second.at(j);
 	const int cellIdHit = (int)thisCalHit->getCellID0();
 
 	double cellEngy = (double)thisCalHit->getEnergy();
@@ -1315,7 +1294,7 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 	  if( thisProjection.newObject )  {
 	    thisProjection = ProjectionInfo( thisCalHit, cellIdHitZ );
 	  } else {
-	    thisProjection.energy += thisCalHit -> getEnergy();
+	    thisProjection.addHit(thisCalHit);
 	  }
 	}
 	// store all hits above _hitMinEnergy energy
@@ -1324,7 +1303,7 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 	  if( thisProjection.newObject )  {
 	    thisProjection = ProjectionInfo( thisCalHit, cellIdHitZ );
 	  } else {
-	    thisProjection.energy += thisCalHit -> getEnergy();
+	    thisProjection.addHit(thisCalHit);
 	  }
 	}
       }
@@ -1337,18 +1316,9 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 	 calHitsProjectionIterator != calHitsProjection.end(); ++calHitsProjectionIterator ){
       const int cellIdProjection = calHitsProjectionIterator->first;
       ProjectionInfo const& projection = calHitsProjectionIterator->second;
-      const double engyCellProjection = projection.energy;
-      const float hitPosV[3] = { (float)projection.getPosition()[0], 
-				 (float)projection.getPosition()[1], 
-				 (float)projection.getPosition()[2]};
-      const int cellIdHitZ = projection.cellIdHitZ;
-      IMPL::CalorimeterHitImpl *calHitNew = new IMPL::CalorimeterHitImpl();
-      calHitNew -> setCellID0(cellIdProjection);
-      calHitNew -> setCellID1(cellIdHitZ);
-      calHitNew -> setEnergy(engyCellProjection);
-      calHitNew -> setPosition(hitPosV);
+      auto calHitNew = std::make_shared<LumiCalHit>(cellIdProjection, projection);
 
-      calHitsCellIdProjection[cellIdProjection] = calHitNew;
+      calHitsCellIdProjection[cellIdProjection] = std::move(calHitNew);
     }
 
     /* --------------------------------------------------------------------------
@@ -1438,9 +1408,6 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 
       for(int hitNow = 0; hitNow < numIdsToErase; hitNow++){
 	int idsToEraseNow = idsToErase[hitNow];
-
-	// cleanUp dynamicly allocated memory
-	delete calHitsCellIdProjection[idsToEraseNow];
 	// erase entry from map
 	calHitsCellIdProjection.erase(idsToEraseNow);
       }
@@ -1497,18 +1464,9 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 	  calHitsProjectionIterator != calHitsProjectionFull.end(); ++calHitsProjectionIterator ){
       const int cellIdProjection = calHitsProjectionIterator->first;
       ProjectionInfo const& projection = calHitsProjectionIterator->second;
-      const float hitPosV[3] = { (float)projection.getPosition()[0], 
-				 (float)projection.getPosition()[1], 
-				 (float)projection.getPosition()[2]};
-      const int cellIdHitZ = projection.cellIdHitZ;
+      auto calHitNew = std::make_shared<LumiCalHit>(cellIdProjection, projection);
 
-      IMPL::CalorimeterHitImpl *calHitNew = new IMPL::CalorimeterHitImpl();
-      calHitNew -> setCellID0(cellIdProjection);
-      calHitNew -> setCellID1(cellIdHitZ);
-      calHitNew -> setEnergy(projection.energy);
-      calHitNew -> setPosition(hitPosV);
-
-      calHitsCellIdProjectionFull[cellIdProjection] = calHitNew;
+      calHitsCellIdProjectionFull[cellIdProjection] = std::move(calHitNew);
       // a flag map for avoiding double counting of clustered cells
       projectionFlag[cellIdProjection] = 0;
     }
@@ -1564,12 +1522,12 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 
 
     // create new clusters around the projection CMs
-    for(std::map < int , IMPL::CalorimeterHitImpl* > :: const_iterator calHitsCellIdIterator = calHitsCellIdGlobal.begin();
-	calHitsCellIdIterator != calHitsCellIdGlobal.end(); ++calHitsCellIdIterator) {
+    for (MapIntCalHit::const_iterator calHitsCellIdIterator = calHitsCellIdGlobal.begin();
+         calHitsCellIdIterator != calHitsCellIdGlobal.end(); ++calHitsCellIdIterator) {
       const int cellIdHit = calHitsCellIdIterator->first;
 
       std::map < int , double > weightedDistanceV;
-      const IMPL::CalorimeterHitImpl * thisHit = calHitsCellIdIterator->second;
+      const auto& thisHit = calHitsCellIdIterator->second;
 
       for( MapIntLCCluster::iterator clusterCMIterator = clusterCM[_maxLayerToAnalyse].begin();
 	   clusterCMIterator != clusterCM[_maxLayerToAnalyse].end(); ++clusterCMIterator) {
@@ -1690,7 +1648,7 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 	const int cellIdHit = cellIds[hitNow];
 
 	std::map < int , double > weightedDistanceV;
-	const IMPL::CalorimeterHitImpl * thisHit = calHitsCellIdGlobal.at(cellIdHit);
+        const auto& thisHit = calHitsCellIdGlobal.at(cellIdHit);
 
 	int numSuperClustersGood = superClusterAccepted.size();
 	for(int superClusterNowGood = 0; superClusterNowGood < numSuperClustersGood; superClusterNowGood++) {
@@ -1763,14 +1721,8 @@ int LumiCalClustererClass::engyInMoliereCorrections ( MapIntCalHit const& calHit
 
 
   // cleanUp dynamically allocated memory
-  for( MapIntCalHit::const_iterator calHitsCellIdIterator = calHitsCellIdProjection.begin(); 
-      calHitsCellIdIterator != calHitsCellIdProjection.end(); ++calHitsCellIdIterator ) {
-    delete calHitsCellIdIterator->second;
-  }
-  for( MapIntCalHit::const_iterator calHitsCellIdIterator = calHitsCellIdProjectionFull.begin();
-      calHitsCellIdIterator != calHitsCellIdProjectionFull.end(); ++calHitsCellIdIterator) {
-    delete calHitsCellIdIterator->second;
-  }
+  calHitsCellIdProjection.clear();
+  calHitsCellIdProjectionFull.clear();
 
   /* --------------------------------------------------------------------------
      re-compute total energy and center of mass of each superCluster (just in case...)

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
@@ -116,7 +116,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
   }
 
   // sort acording to energy in ascending order (lowest energy is first)
-  sort( calHitsLayer.begin(), calHitsLayer.end(), HitEnergyCmpAsc );
+  sort(calHitsLayer.begin(), calHitsLayer.end(), HitEnergyCmpAsc<CalHit>);
 
   /* --------------------------------------------------------------------------
      connect each cal hit to it's highest-energy near neighbor.
@@ -185,7 +185,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
      create clusters from each connected bunch of cal hits.
      -------------------------------------------------------------------------- */
   // sort according to energy in descending order (highest energy is first)
-  sort( calHitsLayer.begin(), calHitsLayer.end(), HitEnergyCmpDesc );
+  sort(calHitsLayer.begin(), calHitsLayer.end(), HitEnergyCmpDesc<VecCalHit::value_type>);
 
   for(int j=0; j<(int)calHitsLayer.size(); j++) {
 
@@ -305,7 +305,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
      -------------------------------------------------------------------------- */
   if(mergeSmallToLargeClusters == 1){
     // sort the clusterIds according to clusterCM energy in ascending order (lowest energy is first)
-    std::vector< std::vector<double> > clusterIdEngyV2;
+    VVDouble clusterIdEngyV2;
 
     for(std::map < int , std::vector<int> > :: iterator clusterIdToCellIdIterator = clusterIdToCellId.begin();
 	clusterIdToCellIdIterator != clusterIdToCellId.end(); ++clusterIdToCellIdIterator) {
@@ -315,7 +315,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
       clusterIdEngyV2.back()[1] = (double)clusterIdToCellIdIterator->first;
     }
 
-    sort(clusterIdEngyV2.begin(),clusterIdEngyV2.end(),clusterCMEnergyCmpAsc);
+    sort(clusterIdEngyV2.begin(), clusterIdEngyV2.end(), clusterCMEnergyCmpAsc<VVDouble::value_type>);
 
     // copy the Ids that are now in order to a std::vector
     for(size_t j=0; j<clusterIdEngyV2.size(); j++)
@@ -403,7 +403,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
     // sort the clusterIds according to clusterCM energy in
     // descending order (highest energy is first)
 
-    std::vector< std::vector<double> > clusterIdEngyV2;
+    VVDouble clusterIdEngyV2;
 
     for(std::map < int , std::vector<int> > :: iterator clusterIdToCellIdIterator = clusterIdToCellId.begin();
 	clusterIdToCellIdIterator != clusterIdToCellId.end(); ++clusterIdToCellIdIterator){
@@ -414,7 +414,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
 
     }
 
-    sort(clusterIdEngyV2.begin(),clusterIdEngyV2.end(),clusterCMEnergyCmpDesc);
+    sort(clusterIdEngyV2.begin(), clusterIdEngyV2.end(), clusterCMEnergyCmpDesc<VVDouble::value_type>);
 
     // copy the Ids that are now in order to a std::vector
     for(size_t j=0; j<clusterIdEngyV2.size(); j++)

--- a/source/LumiCalReco/src/LumiCalClusterer_clusterMerger.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_clusterMerger.cpp
@@ -12,15 +12,9 @@ namespace IMPL{
   class CalorimeterHitImpl;
 }
 
-
-
-
-void LumiCalClustererClass::clusterMerger(	std::map < int , std::vector<double> >		& clusterIdToCellEngy,
-						std::map < int , std::vector<int> >		& clusterIdToCellId,
-						std::map < int , LCCluster > & clusterCM,
-						std::map < int , IMPL::CalorimeterHitImpl* >	calHitsCellIdGlobal ){
-
-
+void LumiCalClustererClass::clusterMerger(MapIntVDouble& clusterIdToCellEngy,
+                                          MapIntVInt& clusterIdToCellId,
+                                          MapIntLCCluster& clusterCM, MapIntCalHit& calHitsCellIdGlobal) {
   int clusterId, clusterId1, clusterId2;
   int numClusters, numClusters2, numElementsInCluster, cellId;
   double	engyNow;

--- a/source/LumiCalReco/src/LumiCalClusterer_energyCorrections.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_energyCorrections.cpp
@@ -15,11 +15,10 @@ namespace IMPL{
   class CalorimeterHitImpl;
 }
 
-void LumiCalClustererClass::energyCorrections (	std::map < int , std::vector<int> >	     & superClusterIdToCellId,
-						std::map < int , std::vector<double> >	     & superClusterIdToCellEngy,
-						std::map < int , LCCluster >		& superClusterCM,
-						std::map < int , IMPL::CalorimeterHitImpl* > const& calHitsCellIdGlobal ) {
-
+void LumiCalClustererClass::energyCorrections(MapIntVInt& superClusterIdToCellId,
+                                              MapIntVDouble& superClusterIdToCellEngy,
+                                              MapIntLCCluster& superClusterCM,
+                                              MapIntCalHit const& calHitsCellIdGlobal) {
   std::map < int , std::vector<int> > :: iterator	superClusterIdToCellIdIterator;
 
   std::vector < int >		cellIdV;
@@ -105,9 +104,9 @@ void LumiCalClustererClass::energyCorrections (	std::map < int , std::vector<int
     for(int hitNow = 0; hitNow < numElementsInCluster; hitNow++){
       cellIdHit = superClusterIdToCellId[superClusterId][hitNow];
 
-      const IMPL::CalorimeterHitImpl* thisHit = calHitsCellIdGlobal.at(cellIdHit);
+      const auto& thisHit = calHitsCellIdGlobal.at(cellIdHit);
       double pos3[2] = { thisHit -> getPosition()[0],
-			 thisHit -> getPosition()[1]};
+			thisHit -> getPosition()[1]};
 
       engyNow = superClusterIdToCellEngy[superClusterId][hitNow];
 
@@ -168,7 +167,7 @@ void LumiCalClustererClass::energyCorrections (	std::map < int , std::vector<int
     for(int hitNow = 0; hitNow < numElementsInSuperCluster; hitNow++){
       cellIdHit = superClusterIdToCellId[superClusterId][hitNow];
 
-      const IMPL::CalorimeterHitImpl* thisHit = calHitsCellIdGlobal.at(cellIdHit);
+      const auto& thisHit = calHitsCellIdGlobal.at(cellIdHit);
       double pos3[2] = { thisHit -> getPosition()[0],
 			 thisHit -> getPosition()[1]};
 

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -48,7 +48,6 @@ std::map < int , double > snbx;
 
     try{
 
-      std::map< int , MapIntPClusterClass > clusterClassMap;
 
       double ThetaMid = (gmc.GlobalParamD[GlobalMethodsClass::ThetaMin] + gmc.GlobalParamD[GlobalMethodsClass::ThetaMax])/2.;
       double ThetaTol = (gmc.GlobalParamD[GlobalMethodsClass::ThetaMax] - gmc.GlobalParamD[GlobalMethodsClass::ThetaMin])/2.;
@@ -82,7 +81,6 @@ std::map < int , double > snbx;
 	     clusterIdToCellIdIterator++) {
 	  const int clusterId = clusterIdToCellIdIterator->first;
 
-	  //	  ClusterClass const* thisCluster = clusterClassMap[armNow][clusterId];
 	  LCCluster const& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
 
 	  const double clusterEnergy = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV , thisClusterInfo.getE());
@@ -145,10 +143,10 @@ std::map < int , double > snbx;
 // empty string OutRootFileName in steering file
 
       if ( OutRootFileName != "" ) {
+        // instantiate a clusterClass object for each mcParticle which was
+        // created infront of LumiCal and was destroyed after lumical.
+        std::map<int, MapIntPClusterClass> clusterClassMap;
 
-// instantiate a clusterClass object for each mcParticle which was created
-// infront of LumiCal and was destroyed after lumical.
-     
 	CreateClusters( LumiCalClusterer._superClusterIdToCellId,
 			LumiCalClusterer._superClusterIdToCellEngy,
 			clusterClassMap,

--- a/source/LumiCalReco/src/OutputManagerClass.cpp
+++ b/source/LumiCalReco/src/OutputManagerClass.cpp
@@ -1,10 +1,10 @@
-
 #include "OutputManagerClass.h"
 #include "Global.hh"
-#include <TROOT.h>
+
 #include <TFile.h>
 #include <TH1F.h>
 #include <TH2F.h>
+#include <TROOT.h>
 #include <TTree.h>
 
 #include <streamlog/loglevels.h>
@@ -13,43 +13,33 @@
 #include <algorithm>
 #include <cassert>
 #include <map>
-#include <string>
 #include <sstream>
+#include <string>
 
+OutputManagerClass::OutputManagerClass()
+    : HisMap1D(),
+      HisMap1DIterator(),
+      HisMap2D(),
+      HisMap2DIterator(),
+      TreeMap(),
+      TreeMapIterator(),
+      TreeIntV(),
+      TreeDoubleV(),
+      OutputRootFileName("LcalOut"),
+      OutDirName("rootOut"),
+      OutputRootFile(NULL),
+      Counter(),
+      CounterIterator(),
+      SkipNEvents(0),
+      WriteRootTrees(1),
+      NumEventsTree(0),
+      MemoryResidentTree(0) {}
 
+OutputManagerClass::~OutputManagerClass() { CleanUp(); }
 
-OutputManagerClass::OutputManagerClass():
-  HisMap1D(),
-  HisMap1DIterator(),
-  HisMap2D(),
-  HisMap2DIterator(),
-  TreeMap(),
-  TreeMapIterator(),
-  TreeIntV(),
-  TreeDoubleV(),
-  OutputRootFileName("LcalOut"), OutDirName("rootOut"),
-  OutputRootFile(NULL),
-  Counter(),
-  CounterIterator(),
-  SkipNEvents(0), WriteRootTrees(1), NumEventsTree(0),
-  MemoryResidentTree(0)
-{
-}
-
-OutputManagerClass::~OutputManagerClass() {
-
-  CleanUp();
-}
-
-
-void OutputManagerClass::Initialize(int treeLocOptNow,
-                                    int skipNEventsNow,
-                                    int numEventsTreeNow,
-                                    std::string outDirNameNow,
-                                    std::string outFileNameNow){
-
-
-  OutDirName = outDirNameNow;
+void OutputManagerClass::Initialize(int treeLocOptNow, int skipNEventsNow, int numEventsTreeNow, std::string outDirNameNow,
+                                    std::string outFileNameNow) {
+  OutDirName         = outDirNameNow;
   OutputRootFileName = outFileNameNow;
 
   SkipNEvents   = skipNEventsNow;
@@ -59,42 +49,49 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
   //	Counter["High engy cluster In negative side"] = 0;
   //	Counter["Bhabhas after selection cuts"]   = 0;
   OutputRootFile = NULL;
-  if ( outFileNameNow == "" ) return ; // nothing to do
+  if (outFileNameNow == "")
+    return;  // nothing to do
 
-  TH1F	* his1;
-  TH2F	* his2;
-  TTree	* tree;
-  Int_t	markerCol = kRed-4, lineCol = kAzure+3, fillCol = kBlue-8;
-  std::string hisName;  int numBins1;  double hisRange1[2];  int numBins2;  double hisRange2[2];
-  MemoryResidentTree  = treeLocOptNow;
-  WriteRootTrees = int(SkipNEvents/double(NumEventsTree))+1;
-
+  TH1F*       his1;
+  TH2F*       his2;
+  TTree*      tree;
+  Int_t       markerCol = kRed - 4, lineCol = kAzure + 3, fillCol = kBlue - 8;
+  std::string hisName;
+  int         numBins1;
+  double      hisRange1[2];
+  int         numBins2;
+  double      hisRange2[2];
+  MemoryResidentTree = treeLocOptNow;
+  WriteRootTrees     = int(SkipNEvents / double(NumEventsTree)) + 1;
 
   /* check that the output directory exists
   std::string  outDirName = "cd "; outDirName += OutDirName;
   assert( !system(outDirName.c_str()) );
   */
-  // it is probably more convenient to check and create if needed (BP) 
+  // it is probably more convenient to check and create if needed (BP)
   std::string command = "mkdir -p ";
   command += OutDirName;
-  if( system( command.c_str() ) ) {
-    exit( EXIT_FAILURE );
+  if (system(command.c_str())) {
+    exit(EXIT_FAILURE);
   }
-  if( MemoryResidentTree == 0 ) {
-  // Open Root file before booking histos/Trees to have diskresident dir
+  if (MemoryResidentTree == 0) {
+    // Open Root file before booking histos/Trees to have diskresident dir
     std::string outFileName = OutDirName;
     outFileName += "/";
     outFileName += OutputRootFileName;
     outFileName += ".root";
-    OutputRootFile = new TFile( outFileName.c_str(),"RECREATE"); 
-  }else{
+    OutputRootFile = new TFile(outFileName.c_str(), "RECREATE");
+  } else {
     // make sure we are at top root dir (BP)
-    gROOT->cd(); 
+    gROOT->cd();
   }
-  hisRange1[0] = 0;	hisRange1[1] = 150;	numBins1 = 3000;
+  hisRange1[0] = 0;
+  hisRange1[1] = 150;
+  numBins1     = 3000;
 
-  hisName = "totEnergyOut";
-  his1 = new TH1F(hisName.c_str(),hisName.c_str(),numBins1,hisRange1[0],hisRange1[1]); HisMap1D[hisName] = his1;
+  hisName           = "totEnergyOut";
+  his1              = new TH1F(hisName.c_str(), hisName.c_str(), numBins1, hisRange1[0], hisRange1[1]);
+  HisMap1D[hisName] = his1;
 
   his1->SetLineColor(lineCol);
   his1->SetFillColor(fillCol);
@@ -107,11 +104,12 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
 
   HisMap1D[hisName] = his1;
 
-
-  hisRange1[0] = 0;	hisRange1[1] = 300;	numBins1 = 300;
+  hisRange1[0] = 0;
+  hisRange1[1] = 300;
+  numBins1     = 300;
 
   hisName = "totEnergyIn";
-  his1 = new TH1F(hisName.c_str(),hisName.c_str(),numBins1,hisRange1[0],hisRange1[1]);
+  his1    = new TH1F(hisName.c_str(), hisName.c_str(), numBins1, hisRange1[0], hisRange1[1]);
 
   his1->SetLineColor(lineCol);
   his1->SetFillColor(fillCol);
@@ -124,8 +122,9 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
 
   HisMap1D[hisName] = his1;
 
-  hisName = "higestEngyParticle_Engy";
-  his1 = new TH1F(hisName.c_str(),hisName.c_str(),numBins1,hisRange1[0],hisRange1[1]); HisMap1D[hisName] = his1;
+  hisName           = "higestEngyParticle_Engy";
+  his1              = new TH1F(hisName.c_str(), hisName.c_str(), numBins1, hisRange1[0], hisRange1[1]);
+  HisMap1D[hisName] = his1;
 
   his1->SetLineColor(lineCol);
   his1->SetFillColor(fillCol);
@@ -138,9 +137,12 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
 
   HisMap1D[hisName] = his1;
 
-  hisRange1[0] = 0;	hisRange1[1] = .1;	numBins1 = 200;
-  hisName = "higestEngyParticle_Theta";
-  his1 = new TH1F(hisName.c_str(),hisName.c_str(),numBins1,hisRange1[0],hisRange1[1]); HisMap1D[hisName] = his1;
+  hisRange1[0]      = 0;
+  hisRange1[1]      = .1;
+  numBins1          = 200;
+  hisName           = "higestEngyParticle_Theta";
+  his1              = new TH1F(hisName.c_str(), hisName.c_str(), numBins1, hisRange1[0], hisRange1[1]);
+  HisMap1D[hisName] = his1;
 
   his1->SetLineColor(lineCol);
   his1->SetFillColor(fillCol);
@@ -153,11 +155,15 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
 
   HisMap1D[hisName] = his1;
 
-
-  hisRange1[0] = 0;	hisRange1[1] = 300;	numBins1 = 300;
-  hisRange2[0] = 0;	hisRange2[1] = .1;	numBins2 = 300;
-  hisName = "thetaEnergyOut_DepositedEngy";
-  his2 = new TH2F(hisName.c_str(),hisName.c_str(),numBins1,hisRange1[0],hisRange1[1],numBins2,hisRange2[0],hisRange2[1]);
+  hisRange1[0] = 0;
+  hisRange1[1] = 300;
+  numBins1     = 300;
+  hisRange2[0] = 0;
+  hisRange2[1] = .1;
+  numBins2     = 300;
+  hisName      = "thetaEnergyOut_DepositedEngy";
+  his2 =
+      new TH2F(hisName.c_str(), hisName.c_str(), numBins1, hisRange1[0], hisRange1[1], numBins2, hisRange2[0], hisRange2[1]);
 
   his2->SetMarkerColor(markerCol);
   his2->SetMarkerStyle(5);
@@ -171,10 +177,15 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
 
   HisMap2D[hisName] = his2;
 
-  hisRange1[0] = -0.5;	hisRange1[1] = 19.5;	numBins1 = 20;
-  hisRange2[0] = -0.5;	hisRange2[1] = 19.5;	numBins2 = 20;
-  hisName = "NumClustersIn_numMCParticlesIn";
-  his2 = new TH2F(hisName.c_str(),hisName.c_str(),numBins1,hisRange1[0],hisRange1[1],numBins2,hisRange2[0],hisRange2[1]);
+  hisRange1[0] = -0.5;
+  hisRange1[1] = 19.5;
+  numBins1     = 20;
+  hisRange2[0] = -0.5;
+  hisRange2[1] = 19.5;
+  numBins2     = 20;
+  hisName      = "NumClustersIn_numMCParticlesIn";
+  his2 =
+      new TH2F(hisName.c_str(), hisName.c_str(), numBins1, hisRange1[0], hisRange1[1], numBins2, hisRange2[0], hisRange2[1]);
 
   his2->SetMarkerColor(markerCol);
   his2->SetMarkerStyle(5);
@@ -188,46 +199,45 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
 
   HisMap2D[hisName] = his2;
 
-
-  hisName = "LumiRecoParticleTree";
-  TreeIntV["nEvt"] = 0;
-  TreeIntV["sign"] = 0;
-  TreeIntV["pdg"] = 0;
+  hisName             = "LumiRecoParticleTree";
+  TreeIntV["nEvt"]    = 0;
+  TreeIntV["sign"]    = 0;
+  TreeIntV["pdg"]     = 0;
   TreeIntV["outFlag"] = 0;
-  TreeIntV["mFlag"] = 0;
-  TreeIntV["nHits"] = 0;
-  TreeIntV["highE"] = 0;
+  TreeIntV["mFlag"]   = 0;
+  TreeIntV["nHits"]   = 0;
+  TreeIntV["highE"]   = 0;
 
-  TreeDoubleV["distTheta"]=0.;
-  TreeDoubleV["distXY"]=0.;
-  TreeDoubleV["engy"]=0.;
-  TreeDoubleV["theta"]=0.;
-  TreeDoubleV["phi"]=0.;
-  TreeDoubleV["rzStart"] = 0.;
-  TreeDoubleV["Xglob"] = 0.;
-  TreeDoubleV["Yglob"] = 0.;
-  TreeDoubleV["Zglob"] = 0.;
+  TreeDoubleV["distTheta"] = 0.;
+  TreeDoubleV["distXY"]    = 0.;
+  TreeDoubleV["engy"]      = 0.;
+  TreeDoubleV["theta"]     = 0.;
+  TreeDoubleV["phi"]       = 0.;
+  TreeDoubleV["rzStart"]   = 0.;
+  TreeDoubleV["Xglob"]     = 0.;
+  TreeDoubleV["Yglob"]     = 0.;
+  TreeDoubleV["Zglob"]     = 0.;
 
-  tree = new TTree(hisName.c_str(),hisName.c_str());
-  tree -> Branch("Event", &TreeIntV["nEvt"], "nEvt/I");
-  tree -> Branch("OutFlag", &TreeIntV["outFlag"], "outFlag/I");
-  tree -> Branch("MatchFlag", &TreeIntV["mFlag"], "mFlag/I");
-  tree -> Branch("distTheta", &TreeDoubleV["distTheta"], "distTheta/D");
-  tree -> Branch("distXY", &TreeDoubleV["distXY"], "distXY/D");
-  tree -> Branch("HighEngy", &TreeIntV["highE"], "highE/I");
-  tree -> Branch("Sign", &TreeIntV["sign"], "sign/I");
-  tree -> Branch("NHits", &TreeIntV["nHits"], "nHits/I");
-  tree -> Branch("Energy", &TreeDoubleV["engy"], "engy/D");
-  tree -> Branch("EngyMC", &TreeDoubleV["engyMC"], "engyMC/D");
-  tree -> Branch("Theta", &TreeDoubleV["theta"], "theta/D");
-  tree -> Branch("ThetaMC", &TreeDoubleV["thetaMC"], "thetaMC/D");
-  tree -> Branch("Phi", &TreeDoubleV["phi"], "phi/D");
-  tree -> Branch("RZstart", &TreeDoubleV["rzStart"], "rzStart/D");
-  tree -> Branch("Xstart", &TreeDoubleV["Xglob"], "Xglob/D");
-  tree -> Branch("Ystart", &TreeDoubleV["Yglob"], "Yglob/D");
-  tree -> Branch("Zstart", &TreeDoubleV["Zglob"], "Zglob/D");
+  tree = new TTree(hisName.c_str(), hisName.c_str());
+  tree->Branch("Event", &TreeIntV["nEvt"], "nEvt/I");
+  tree->Branch("OutFlag", &TreeIntV["outFlag"], "outFlag/I");
+  tree->Branch("MatchFlag", &TreeIntV["mFlag"], "mFlag/I");
+  tree->Branch("distTheta", &TreeDoubleV["distTheta"], "distTheta/D");
+  tree->Branch("distXY", &TreeDoubleV["distXY"], "distXY/D");
+  tree->Branch("HighEngy", &TreeIntV["highE"], "highE/I");
+  tree->Branch("Sign", &TreeIntV["sign"], "sign/I");
+  tree->Branch("NHits", &TreeIntV["nHits"], "nHits/I");
+  tree->Branch("Energy", &TreeDoubleV["engy"], "engy/D");
+  tree->Branch("EngyMC", &TreeDoubleV["engyMC"], "engyMC/D");
+  tree->Branch("Theta", &TreeDoubleV["theta"], "theta/D");
+  tree->Branch("ThetaMC", &TreeDoubleV["thetaMC"], "thetaMC/D");
+  tree->Branch("Phi", &TreeDoubleV["phi"], "phi/D");
+  tree->Branch("RZstart", &TreeDoubleV["rzStart"], "rzStart/D");
+  tree->Branch("Xstart", &TreeDoubleV["Xglob"], "Xglob/D");
+  tree->Branch("Ystart", &TreeDoubleV["Yglob"], "Yglob/D");
+  tree->Branch("Zstart", &TreeDoubleV["Zglob"], "Zglob/D");
 
-  TreeMap[ hisName] = tree;
+  TreeMap[hisName]    = tree;
   TreeDoubleV["vtxX"] = 0.;
   TreeDoubleV["vtxY"] = 0.;
   TreeDoubleV["vtxZ"] = 0.;
@@ -237,51 +247,50 @@ void OutputManagerClass::Initialize(int treeLocOptNow,
   TreeDoubleV["endX"] = 0.;
   TreeDoubleV["endY"] = 0.;
   TreeDoubleV["endZ"] = 0.;
- 
+
   hisName = "LumiMCParticleTree";
-  tree = new TTree(hisName.c_str(),hisName.c_str());
-  tree -> Branch("Event", &TreeIntV["nEvt"], "nEvt/I");
-  tree -> Branch("Sign", &TreeIntV["sign"], "sign/I");
-  tree -> Branch("PDG", &TreeIntV["pdg"], "pdg/I");
-  tree -> Branch("Energy", &TreeDoubleV["engy"], "engy/D");
-  tree -> Branch("Theta", &TreeDoubleV["theta"], "theta/D");
-  tree -> Branch("Phi", &TreeDoubleV["phi"], "phi/D");
-  tree -> Branch("VX", &TreeDoubleV["vtxX"], "vtxX/D");
-  tree -> Branch("VY", &TreeDoubleV["vtxY"], "vtxY/D");
-  tree -> Branch("VZ", &TreeDoubleV["vtxZ"], "vtxZ/D");
-  tree -> Branch("BegX", &TreeDoubleV["begX"], "begX/D");
-  tree -> Branch("BegY", &TreeDoubleV["begY"], "begY/D");
-  tree -> Branch("BegZ", &TreeDoubleV["begZ"], "begZ/D");
-  tree -> Branch("EndX", &TreeDoubleV["endX"], "endX/D");
-  tree -> Branch("EndY", &TreeDoubleV["endY"], "endY/D");
-  tree -> Branch("EndZ", &TreeDoubleV["endZ"], "endZ/D");
+  tree    = new TTree(hisName.c_str(), hisName.c_str());
+  tree->Branch("Event", &TreeIntV["nEvt"], "nEvt/I");
+  tree->Branch("Sign", &TreeIntV["sign"], "sign/I");
+  tree->Branch("PDG", &TreeIntV["pdg"], "pdg/I");
+  tree->Branch("Energy", &TreeDoubleV["engy"], "engy/D");
+  tree->Branch("Theta", &TreeDoubleV["theta"], "theta/D");
+  tree->Branch("Phi", &TreeDoubleV["phi"], "phi/D");
+  tree->Branch("VX", &TreeDoubleV["vtxX"], "vtxX/D");
+  tree->Branch("VY", &TreeDoubleV["vtxY"], "vtxY/D");
+  tree->Branch("VZ", &TreeDoubleV["vtxZ"], "vtxZ/D");
+  tree->Branch("BegX", &TreeDoubleV["begX"], "begX/D");
+  tree->Branch("BegY", &TreeDoubleV["begY"], "begY/D");
+  tree->Branch("BegZ", &TreeDoubleV["begZ"], "begZ/D");
+  tree->Branch("EndX", &TreeDoubleV["endX"], "endX/D");
+  tree->Branch("EndY", &TreeDoubleV["endY"], "endY/D");
+  tree->Branch("EndZ", &TreeDoubleV["endZ"], "endZ/D");
 
   TreeMap[hisName] = tree;
-  
 
   return;
 }
 
-void OutputManagerClass::CleanUp(){
-
+void OutputManagerClass::CleanUp() {
   // 1D histogram std::map
-  streamlog_out(DEBUG)<<"OutputManagerClass::CleanUp: cleaning 1D map .........\n";
-  HisMap1DIterator  = HisMap1D.begin();
-  for(; HisMap1DIterator != HisMap1D.end(); ++HisMap1DIterator) {
-    if ( HisMap1DIterator->second ) delete HisMap1DIterator->second;
+  streamlog_out(DEBUG) << "OutputManagerClass::CleanUp: cleaning 1D map .........\n";
+  HisMap1DIterator = HisMap1D.begin();
+  for (; HisMap1DIterator != HisMap1D.end(); ++HisMap1DIterator) {
+    if (HisMap1DIterator->second)
+      delete HisMap1DIterator->second;
   }
 
   // 2D histogram std::map
-  streamlog_out(DEBUG)<<"OutputManagerClass::CleanUp: cleaning 2D map .........\n";
-  HisMap2DIterator  = HisMap2D.begin();
-  for(;HisMap2DIterator != HisMap2D.end(); ++HisMap2DIterator) {
+  streamlog_out(DEBUG) << "OutputManagerClass::CleanUp: cleaning 2D map .........\n";
+  HisMap2DIterator = HisMap2D.begin();
+  for (; HisMap2DIterator != HisMap2D.end(); ++HisMap2DIterator) {
     delete HisMap2DIterator->second;
   }
 
   // tree std::map
-  streamlog_out(DEBUG)<<"OutputManagerClass::CleanUp: cleaning Tree map .......\n";
-  TreeMapIterator   = TreeMap.begin();
-  for(; TreeMapIterator != TreeMap.end(); ++TreeMapIterator) {
+  streamlog_out(DEBUG) << "OutputManagerClass::CleanUp: cleaning Tree map .......\n";
+  TreeMapIterator = TreeMap.begin();
+  for (; TreeMapIterator != TreeMap.end(); ++TreeMapIterator) {
     delete TreeMapIterator->second;
   }
 
@@ -292,66 +301,70 @@ void OutputManagerClass::CleanUp(){
   return;
 }
 
-void OutputManagerClass::FillRootTree( const std::string &treeName){
-  TreeMap[ treeName ]->Fill();
-}
+void OutputManagerClass::FillRootTree(const std::string& treeName) { TreeMap[treeName]->Fill(); }
 
-void OutputManagerClass::WriteToRootTree(std::string optName, int nEvtNow){
+void OutputManagerClass::WriteToRootTree(std::string optName, int nEvtNow) {
+  if (!OutputRootFile)
+    return;
 
-  if ( !OutputRootFile ) return;
-
-    if ( MemoryResidentTree == 1 ){ 
-    //memory resident tree 
-    if( int(nEvtNow/double(NumEventsTree)) ==  WriteRootTrees || optName == "forceWrite") {
+  if (MemoryResidentTree == 1) {
+    //memory resident tree
+    if (int(nEvtNow / double(NumEventsTree)) == WriteRootTrees || optName == "forceWrite") {
       // OutputRootFileName = "./";  one migth want to write in some other place (BP)
-    std::string outFileName = OutDirName;
-    outFileName += "/";
-    outFileName += OutputRootFileName;
-    outFileName += "_";
-    //    OutputRootFileName += WriteRootTrees;  <---  bad idea (BP)
-     std::stringstream fnum;
-     fnum << WriteRootTrees-1;
-     outFileName += fnum.str();
-     outFileName += ".root";
-     OutputRootFile = new TFile( outFileName.c_str(),"RECREATE");
-    // 1D histogram std::map
-     HisMap1DIterator  = HisMap1D.begin();
-     for(; HisMap1DIterator != HisMap1D.end(); ++HisMap1DIterator) {
-      HisMap1DIterator->second -> Write();
-      HisMap1DIterator->second -> Reset();
-     }
-
-    // 2D histogram map
-    HisMap2DIterator  = HisMap2D.begin();
-    for(;HisMap2DIterator != HisMap2D.end();++HisMap2DIterator) {
-      HisMap2DIterator->second -> Write();
-      HisMap2DIterator->second -> Reset();
-    }
-
-    // tree map
-    TreeMapIterator   = TreeMap.begin();
-    for(; TreeMapIterator != TreeMap.end(); ++TreeMapIterator) {
-      TTree* pTreeNow = TreeMapIterator->second;
-      if( pTreeNow ) {
-	pTreeNow -> Write();
-        pTreeNow -> Reset();
+      std::string outFileName = OutDirName;
+      outFileName += "/";
+      outFileName += OutputRootFileName;
+      outFileName += "_";
+      //    OutputRootFileName += WriteRootTrees;  <---  bad idea (BP)
+      std::stringstream fnum;
+      fnum << WriteRootTrees - 1;
+      outFileName += fnum.str();
+      outFileName += ".root";
+      OutputRootFile = new TFile(outFileName.c_str(), "RECREATE");
+      // 1D histogram std::map
+      HisMap1DIterator = HisMap1D.begin();
+      for (; HisMap1DIterator != HisMap1D.end(); ++HisMap1DIterator) {
+        HisMap1DIterator->second->Write();
+        HisMap1DIterator->second->Reset();
       }
-    }
 
-    OutputRootFile -> Close();
-    delete	OutputRootFile;
-    streamlog_out(MESSAGE) <<"\n"<< "OutputManagerClass::WriteToRootTree: Went through  " << nEvtNow << "  events..." << "\n";
-    streamlog_out(MESSAGE) <<"OutputManagerClass::WriteToRootTree: Root file  " << outFileName << " written" << "\n";
-    WriteRootTrees++;
-  }
-  }else{
-      // disk resident hits/trees
-    if( optName == "forceWrite" ){
-      OutputRootFile -> Write();
-      OutputRootFile -> Close();
-      streamlog_out(MESSAGE) <<"\n"<< "OutputManagerClass::WriteToRootTree: Went through  " << nEvtNow << "  events..." << "\n";
-      streamlog_out(MESSAGE) <<"OutputManagerClass::WriteToRootTree: Root file  " << OutputRootFile->GetName() << " written" << "\n";
-      delete	OutputRootFile;
+      // 2D histogram map
+      HisMap2DIterator = HisMap2D.begin();
+      for (; HisMap2DIterator != HisMap2D.end(); ++HisMap2DIterator) {
+        HisMap2DIterator->second->Write();
+        HisMap2DIterator->second->Reset();
+      }
+
+      // tree map
+      TreeMapIterator = TreeMap.begin();
+      for (; TreeMapIterator != TreeMap.end(); ++TreeMapIterator) {
+        TTree* pTreeNow = TreeMapIterator->second;
+        if (pTreeNow) {
+          pTreeNow->Write();
+          pTreeNow->Reset();
+        }
+      }
+
+      OutputRootFile->Close();
+      delete OutputRootFile;
+      streamlog_out(MESSAGE) << "\n"
+                             << "OutputManagerClass::WriteToRootTree: Went through  " << nEvtNow << "  events..."
+                             << "\n";
+      streamlog_out(MESSAGE) << "OutputManagerClass::WriteToRootTree: Root file  " << outFileName << " written"
+                             << "\n";
+      WriteRootTrees++;
+    }
+  } else {
+    // disk resident hits/trees
+    if (optName == "forceWrite") {
+      OutputRootFile->Write();
+      OutputRootFile->Close();
+      streamlog_out(MESSAGE) << "\n"
+                             << "OutputManagerClass::WriteToRootTree: Went through  " << nEvtNow << "  events..."
+                             << "\n";
+      streamlog_out(MESSAGE) << "OutputManagerClass::WriteToRootTree: Root file  " << OutputRootFile->GetName() << " written"
+                             << "\n";
+      delete OutputRootFile;
     }
   }
 

--- a/source/LumiCalReco/src/OutputManagerClass.cpp
+++ b/source/LumiCalReco/src/OutputManagerClass.cpp
@@ -272,28 +272,8 @@ void OutputManagerClass::Initialize(int treeLocOptNow, int skipNEventsNow, int n
 }
 
 void OutputManagerClass::CleanUp() {
-  // 1D histogram std::map
-  streamlog_out(DEBUG) << "OutputManagerClass::CleanUp: cleaning 1D map .........\n";
-  HisMap1DIterator = HisMap1D.begin();
-  for (; HisMap1DIterator != HisMap1D.end(); ++HisMap1DIterator) {
-    if (HisMap1DIterator->second)
-      delete HisMap1DIterator->second;
-  }
 
-  // 2D histogram std::map
-  streamlog_out(DEBUG) << "OutputManagerClass::CleanUp: cleaning 2D map .........\n";
-  HisMap2DIterator = HisMap2D.begin();
-  for (; HisMap2DIterator != HisMap2D.end(); ++HisMap2DIterator) {
-    delete HisMap2DIterator->second;
-  }
-
-  // tree std::map
-  streamlog_out(DEBUG) << "OutputManagerClass::CleanUp: cleaning Tree map .......\n";
-  TreeMapIterator = TreeMap.begin();
-  for (; TreeMapIterator != TreeMap.end(); ++TreeMapIterator) {
-    delete TreeMapIterator->second;
-  }
-
+  //objects are owned by the root file, no need for cleaning up objects
   TreeMap.clear();
   HisMap2D.clear();
   HisMap1D.clear();

--- a/source/LumiCalReco/src/ProjectionInfo.cpp
+++ b/source/LumiCalReco/src/ProjectionInfo.cpp
@@ -1,8 +1,5 @@
 #include "ProjectionInfo.hh"
-
-//LCIO
-#include <IMPL/CalorimeterHitImpl.h>
-
+#include "LumiCalHit.hh"
 
 ProjectionInfo::ProjectionInfo (): energy (0.0), cellIdHitZ(0), newObject(true) {
   position[0] = 0.0;
@@ -10,10 +7,15 @@ ProjectionInfo::ProjectionInfo (): energy (0.0), cellIdHitZ(0), newObject(true) 
   position[2] = 0.0;
 }
 
-
-ProjectionInfo::ProjectionInfo ( IMPL::CalorimeterHitImpl const* calHit, int cellIdZ):
-  energy ( calHit->getEnergy() ), cellIdHitZ(cellIdZ), newObject(false){
+ProjectionInfo::ProjectionInfo(CalHit const& calHit, int cellIdZ)
+    : energy(calHit->getEnergy()), cellIdHitZ(cellIdZ), newObject(false) {
   position[0] = calHit->getPosition()[0];
   position[1] = calHit->getPosition()[1];
   position[2] = calHit->getPosition()[2];
+  hits.insert(calHit->beginHits(), calHit->endHits());
+}
+
+void ProjectionInfo::addHit(CalHit const& calHit) {
+  hits.insert(calHit->beginHits(), calHit->endHits());
+  energy += calHit->getEnergy();
 }

--- a/source/LumiCalReco/src/VirtualCluster.cpp
+++ b/source/LumiCalReco/src/VirtualCluster.cpp
@@ -3,20 +3,9 @@
 #include <iostream>
 #include <iomanip>
 
+VirtualCluster::VirtualCluster() : _position{0.0, 0.0, 0.0} {}
 
-VirtualCluster::VirtualCluster()
-{
-  _position[0] = 0.0;
-  _position[1] = 0.0;
-  _position[2] = 0.0;
-}
-
-VirtualCluster::VirtualCluster(double x, double y, double z)
-{
-  _position[0] = x;
-  _position[1] = y;
-  _position[2] = z;
-}
+VirtualCluster::VirtualCluster(double x, double y, double z) : _position{x, y, z} {}
 
 void VirtualCluster::clear() {
   _position[0] = 0.0;

--- a/source/MarlinProcessors/src/MarlinLumiCalClusterer.cc
+++ b/source/MarlinProcessors/src/MarlinLumiCalClusterer.cc
@@ -69,6 +69,9 @@ MarlinLumiCalClusterer::MarlinLumiCalClusterer() : Processor("MarlinLumiCalClust
 			  LumiInColName ,
 			  std::string("LumiCalCollection") ) ;
 
+  registerOutputCollection(LCIO::CALORIMETERHIT, "LumiCal_Hits", "Collection of CalorimtersHits from the LumiCal",
+                           LumiOutColName, LumiOutColName);
+
   registerOutputCollection(LCIO::CLUSTER,
 			   "LumiCal_Clusters" ,
 			   "Collection of Cluster found in the LumiCal" ,
@@ -190,6 +193,7 @@ void MarlinLumiCalClusterer::init(){
 
   //LumiCalClusterer = new LumiCalClustererClass(LumiInColName);
   LumiCalClusterer.setLumiCollectionName(LumiInColName);
+  LumiCalClusterer.setLumiOutCollectionName(LumiOutColName);
   LumiCalClusterer.init( gmc );
   LumiCalClusterer.setCutOnFiducialVolume(_cutOnFiducialVolume);
 


### PR DESCRIPTION

BEGINRELEASENOTES
- LumiCalClusterer: Assign hits to the created cluster, fixes #8 
  - Instead of the simulated hits collection a Digitized Hits collection for the LumiCal should be passed. If a SimCalorimterHit collection is passed dummy digitization is done and the CalorimeterHit collection is written out, controlled by Parameter `LumiCal_Hits` with default value `LumiCalHits`

ENDRELEASENOTES