### PR TITLE
Fix resolutions

### DIFF
--- a/source/LumiCalReco/include/Global.hh
+++ b/source/LumiCalReco/include/Global.hh
@@ -1,6 +1,46 @@
 #ifndef Global_hh
 #define Global_hh 1
 
+#include <map>
+#include <memory>
+#include <vector>
+
+class LumiCalHit;
+class LCCluster;
+class ProjectionInfo;
+class VirtualCluster;
+
+using CalHit    = std::shared_ptr<LumiCalHit>;
+using VecCalHit = std::vector<CalHit>;
+using VDouble   = std::vector<double>;
+using VInt      = std::vector<int>;
+
+using MapIntCalHit    = std::map<int, CalHit>;
+using MapIntLCCluster = std::map<int, LCCluster>;
+
+using MapIntVCalHit = std::map<int, VecCalHit>;
+using MapIntVDouble = std::map<int, VDouble>;
+using MapIntVInt    = std::map<int, VInt>;
+
+using MapIntMapIntLCCluster = std::map<int, MapIntLCCluster>;
+using MapIntMapIntVCalHit   = std::map<int, MapIntVCalHit>;
+using MapIntMapIntVDouble   = std::map<int, MapIntVDouble>;
+using MapIntMapIntVInt      = std::map<int, MapIntVInt>;
+using MapIntProjectionInfo  = std::map<int, ProjectionInfo>;
+using MapIntVirtualCluster  = std::map<int, VirtualCluster>;
+using MapIntDouble          = std::map<int, double>;
+using MapIntInt             = std::map<int, int>;
+
+using MapIntMapIntCalHit = std::map<int, MapIntCalHit>;
+
+using VMapIntCalHit         = std::vector<MapIntCalHit>;
+using VMapIntInt            = std::vector<MapIntInt>;
+using VMapIntLCCluster      = std::vector<MapIntLCCluster>;
+using VMapIntVInt           = std::vector<MapIntVInt>;
+using VMapIntVirtualCluster = std::vector<MapIntVirtualCluster>;
+
+using VVDouble = std::vector<VDouble>;
+
 #define _VERY_SMALL_NUMBER 1e-9
 #define _CLUSTER_MERGE_DEBUG 0
 #define _GLOBAL_COUNTERS_UPDATE_DEBUG 0
@@ -8,4 +48,4 @@
 #define _CLUSTER_STORE_DEBUG 0
 #define _BP_DEBUG 0
 
-#endif // Global_hh
+#endif  // Global_hh

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -54,10 +54,8 @@ public:
     ClusterMinNumHits,
     MinHitEnergy,
     MinClusterEngyGeV,
-    MinClusterEngySignal,
     MiddleEnergyHitBoundFrac,
     WeightingMethod,
-    GeV_to_Signal,
     Signal_to_GeV,
     BeamCrossingAngle,
     LumiInColName,
@@ -98,15 +96,14 @@ public:
   ParametersDouble GlobalParamD;
   ParametersString GlobalParamS;
 
-  double SignalGevConversion( Parameter_t optName , double valNow );
+  double toSignal(double valNow) const;
+  double toGev(double valNow) const;
+
   void	ThetaPhiCell(int cellId , std::map <GlobalMethodsClass::Coordinate_t , double> & thetaPhiCell);
 
   static void CellIdZPR(int cellId, int& cellZ, int& cellPhi, int& cellR, int& arm);
   static int  CellIdZPR(int cellZ, int cellPhi, int cellR, int arm);
   static int  CellIdZPR(int cellId, Coordinate_t ZPR);
-
-  double getCalibrationFactor() const { return m_energyCalibrationFactor; }
-  void setCalibrationFactor(double cf) { m_energyCalibrationFactor = cf; }
 
   void PrintAllParameters() const;
 
@@ -115,6 +112,8 @@ public:
   static double posWeight(double cellEngy, double totEngy, GlobalMethodsClass::WeightingMethod_t method,
                           double logWeightConstNow);
 
+  inline double getCalibrationFactor() const { return GlobalParamD.at(Signal_to_GeV); }
+
 private:
   void SetGeometryGear();
   bool SetGeometryDD4HEP();
@@ -122,7 +121,6 @@ private:
   const TGeoHMatrix *_forwardCalo;
   const TGeoHMatrix *_backwardCalo;
 
-  double m_energyCalibrationFactor = 1.0;
 };
 
 

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -111,6 +111,9 @@ public:
 
   inline bool isUsingDD4hep() const { return _useDD4hep; }
 
+  static double posWeight(double cellEngy, double totEngy, GlobalMethodsClass::WeightingMethod_t method,
+                          double logWeightConstNow);
+
 private:
   void SetGeometryGear();
   bool SetGeometryDD4HEP();

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -23,12 +23,12 @@ class TGeoHMatrix;
 
 
 class GlobalMethodsClass {
-
- private:
+private:
   std::string _procName;
   bool _useDD4hep;
 
- public:
+public:
+  enum WeightingMethod_t { LogMethod = -1, EnergyMethod = 1 };
 
   enum Parameter_t{
     ZStart,
@@ -76,7 +76,6 @@ class GlobalMethodsClass {
   
   static std::string GetParameterName ( Parameter_t par );
 
-  typedef std::string                           WeightingMethod_t;
   typedef std::map < Parameter_t, int >         ParametersInt;
   typedef std::map < Parameter_t, double >      ParametersDouble;
   typedef std::map < Parameter_t, std::string > ParametersString;
@@ -89,9 +88,9 @@ class GlobalMethodsClass {
   virtual ~GlobalMethodsClass();
  
   void SetConstants( marlin::Processor* procPTR );
-  static WeightingMethod_t LogMethod;
-  static WeightingMethod_t EnergyMethod;
-  static double EnergyCalibrationFactor;
+  WeightingMethod_t getMethod(std::string const& methodName) const;
+
+  WeightingMethod_t method = LogMethod;
 
   double _backwardRotationPhi;
   ParametersInt    GlobalParamI;
@@ -105,6 +104,9 @@ class GlobalMethodsClass {
   static int  CellIdZPR(int cellZ, int cellPhi, int cellR, int arm);
   static int  CellIdZPR(int cellId, Coordinate_t ZPR);
 
+  double getCalibrationFactor() const { return m_energyCalibrationFactor; }
+  void setCalibrationFactor(double cf) { m_energyCalibrationFactor = cf; }
+
   void PrintAllParameters() const;
 
   inline bool isUsingDD4hep() const { return _useDD4hep; }
@@ -116,6 +118,7 @@ private:
   const TGeoHMatrix *_forwardCalo;
   const TGeoHMatrix *_backwardCalo;
 
+  double m_energyCalibrationFactor = 1.0;
 };
 
 

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -39,6 +39,7 @@ public:
     NumCellsPhi,
     NumCellsZ,
     RCellLength,
+    RCellOffset,
     PhiCellLength,
     ZLayerThickness,
     ZLayerPhiOffset,

--- a/source/LumiCalReco/include/LCCluster.hh
+++ b/source/LumiCalReco/include/LCCluster.hh
@@ -50,6 +50,9 @@ public:
 
   inline VecCalHit const& getCaloHits() const { return _caloHits; }
 
+  /// calculate the cluster position based on the caloHits associated to the cluster
+  void recalculatePositionFromHits(GlobalMethodsClass const& gmc);
+
 private:
 
   void CalculatePhi();

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -86,7 +86,7 @@ protected:
   GlobalMethodsClass::WeightingMethod_t _methodCM;
   double	_moliereRadius;
   double	_thetaContainmentBounds[2];
-  double	_minSeparationDistance, _minClusterEngyGeV, _minClusterEngySignal;
+  double	_minSeparationDistance, _minClusterEngyGeV;
 
   MapIntDouble _totEngyArm;
   MapIntInt    _numHitsInArm;

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -184,15 +184,16 @@ protected:
   int	getNeighborId( int	cellId,
 		       int	neighborIndex );
 
-  template <class T> double posWeight(T const& calHit, GlobalMethodsClass::WeightingMethod_t method);
+  template <class T> double posWeight(T const& calHit, GlobalMethodsClass::WeightingMethod_t method) const;
 
   template <class T>
-  double posWeightTrueCluster(T const& calHit, double cellEngy, GlobalMethodsClass::WeightingMethod_t method);
+  double posWeightTrueCluster(T const& calHit, double cellEngy, GlobalMethodsClass::WeightingMethod_t method) const;
 
-  template <class T> double posWeight(T const& calHit, double totEngy, GlobalMethodsClass::WeightingMethod_t method);
+  template <class T> double posWeight(T const& calHit, double totEngy, GlobalMethodsClass::WeightingMethod_t method) const;
 
   template <class T>
-  double posWeight(T const& calHit, double totEngy, GlobalMethodsClass::WeightingMethod_t method, double logWeightConstNow);
+  double posWeight(T const& calHit, double totEngy, GlobalMethodsClass::WeightingMethod_t method,
+                   double logWeightConstNow) const;
 
   double	distance2DPolar( double * pos1,
 				 double * pos2 );

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -39,35 +39,6 @@ namespace EVENT {
 }
 
 class LumiCalClustererClass {
-  typedef std::vector < double >                  VDouble;
-  typedef std::vector < int >                     VInt;
-
-  typedef std::map<int, CalHit>                         MapIntCalHit;
-  typedef std::map < int , LCCluster >                  MapIntLCCluster;
-
-  typedef std::map < int , VecCalHit >                  MapIntVCalHit;
-  typedef std::map < int , VDouble >                    MapIntVDouble;
-  typedef std::map < int , VInt >                       MapIntVInt;
-
-  typedef std::map < int , MapIntLCCluster >            MapIntMapIntLCCluster;
-  typedef std::map < int , MapIntVCalHit >              MapIntMapIntVCalHit;
-  typedef std::map < int , MapIntVDouble >              MapIntMapIntVDouble; 
-  typedef std::map < int , MapIntVInt >                 MapIntMapIntVInt; 
-  typedef std::map < int , ProjectionInfo >             MapIntProjectionInfo;
-  typedef std::map < int , VirtualCluster >             MapIntVirtualCluster;
-  typedef std::map < int , double >                     MapIntDouble;
-  typedef std::map < int , int >                        MapIntInt;
-
-  typedef std::map < int , MapIntCalHit > MapIntMapIntCalHit;
-
-
-  typedef std::vector < MapIntCalHit >         VMapIntCalHit;
-  typedef std::vector < MapIntInt >            VMapIntInt;
-  typedef std::vector < MapIntLCCluster >      VMapIntLCCluster;
-  typedef std::vector < MapIntVInt >           VMapIntVInt;
-  typedef std::vector < MapIntVirtualCluster > VMapIntVirtualCluster;
-
-  typedef std::vector < VDouble >              VVDouble;
 
 public:
 

--- a/source/LumiCalReco/include/LumiCalHit.hh
+++ b/source/LumiCalReco/include/LumiCalHit.hh
@@ -57,7 +57,4 @@ public:
   const double* getPosition() const { return m_position; }
 };
 
-using CalHit    = std::shared_ptr<LumiCalHit>;
-using VecCalHit = std::vector<CalHit>;
-
 #endif  // LUMICALHIT_HH

--- a/source/LumiCalReco/src/ClusterClass.cpp
+++ b/source/LumiCalReco/src/ClusterClass.cpp
@@ -189,7 +189,7 @@ int ClusterClass::ResetStats() {
     OutsideReason = "Reconstructed outside the fiducial volume";
   }
 
-  if (Engy < gmc.GlobalParamD[GlobalMethodsClass::MinClusterEngySignal]) {
+  if (Engy < gmc.GlobalParamD[GlobalMethodsClass::MinClusterEngyGeV]) {
     OutsideFlag = 1;
     OutsideReason = "Cluster energy below minimum";
   }
@@ -204,7 +204,7 @@ void ClusterClass::PrintInfo(){
     << "ClusterClass Information:   " << Id << std::endl
     << std::setw(30) << "sign, engyHits, engyMC, nHits:"
     << std::setw(13) << SignMC
-    << std::setw(13) << gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV , Engy)
+    << std::setw(13) << Engy
     << std::setw(13) << EngyMC
     << std::setw(13) << Hit.size() << std::endl
     << std::setw(30) << "theta mc,rec:  "

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -177,12 +177,12 @@ void GlobalMethodsClass::SetConstants( marlin::Processor* procPTR ) {
   val = ( val <= GlobalParamD[PhiCellLength] ) ? val : val*M_PI/180.;
   GlobalParamD[ZLayerPhiOffset] = val; 
 
-  m_energyCalibrationFactor = _lcalRecoPars->getFloatVal("EnergyCalibConst");
+  GlobalParamD[Signal_to_GeV] = 1. / _lcalRecoPars->getFloatVal("EnergyCalibConst");
 
   // logarithmic constant for position reconstruction
   GlobalParamD[LogWeightConstant] = _lcalRecoPars->getFloatVal("LogWeigthConstant");
   
-  GlobalParamD[MinHitEnergy] = _lcalRecoPars->getFloatVal("MinHitEnergy");
+  GlobalParamD[MinHitEnergy] = toGev(_lcalRecoPars->getFloatVal("MinHitEnergy"));
   GlobalParamD[MiddleEnergyHitBoundFrac] = _lcalRecoPars->getFloatVal(  "MiddleEnergyHitBoundFrac" );
   GlobalParamD[ElementsPercentInShowerPeakLayer] = _lcalRecoPars->getFloatVal(  "ElementsPercentInShowerPeakLayer" );
   GlobalParamI[ClusterMinNumHits]   = _lcalRecoPars->getIntVal(  "ClusterMinNumHits" );
@@ -201,9 +201,7 @@ void GlobalMethodsClass::SetConstants( marlin::Processor* procPTR ) {
 
   // minimal energy of a single cluster
   GlobalParamD[MinClusterEngyGeV] = _lcalRecoPars->getFloatVal(  "MinClusterEngy" );  // value in GeV
-  GlobalParamD[MinClusterEngySignal] = SignalGevConversion(GeV_to_Signal , GlobalParamD[MinClusterEngyGeV]); 
-  // conversion factor "detector Signal to primary particle energy"
-  GlobalParamD[Signal_to_GeV] = SignalGevConversion( Signal_to_GeV, 1. );             
+
   // hits positions weighting method 
   GlobalParamS[WeightingMethod] = _lcalRecoPars->getStringVal(  "WeightingMethod" );
   GlobalParamD[ElementsPercentInShowerPeakLayer] = _lcalRecoPars->getFloatVal("ElementsPercentInShowerPeakLayer");
@@ -220,30 +218,9 @@ void GlobalMethodsClass::SetConstants( marlin::Processor* procPTR ) {
 
 }
 
+double GlobalMethodsClass::toSignal(double value) const { return value * getCalibrationFactor(); }
 
-/* --------------------------------------------------------------------------
-   ccccccccc
-   -------------------------------------------------------------------------- */
-double GlobalMethodsClass::SignalGevConversion( Parameter_t optName , double valNow ){
-
-#pragma message("FIXME: SignalToGeV conversion")
-  double	returnVal = -1;
-  //  const double conversionFactor(0.0105*1789/1500*(1488/1500.0));
-  //  const double conversionFactor(0.0105);
-  //const double conversionFactor(0.0105);
-
-  if(optName == GeV_to_Signal)
-    returnVal = valNow * m_energyCalibrationFactor;
-  //		returnVal = valNow * .0105 + .0013;
-
-  if(optName == Signal_to_GeV)
-    returnVal = valNow / m_energyCalibrationFactor;
-  //		returnVal = (valNow-.0013) / .0105;
-
-  return returnVal;
-}
-
-
+double GlobalMethodsClass::toGev(double value) const { return value / getCalibrationFactor(); }
 
 void GlobalMethodsClass::ThetaPhiCell(int cellId , std::map <GlobalMethodsClass::Coordinate_t , double> &thetaPhiCell) {
 
@@ -298,10 +275,8 @@ std::string GlobalMethodsClass::GetParameterName ( Parameter_t par ){
   case ClusterMinNumHits:                return "ClusterMinNumHits";
   case MinHitEnergy:                     return "MinHitEnergy";
   case MinClusterEngyGeV:	         return "MinClusterEngyGeV";
-  case MinClusterEngySignal:	         return "MinClusterEngySignal";
   case MiddleEnergyHitBoundFrac:         return "MiddleEnergyHitBoundFrac";
   case WeightingMethod:                  return "WeightingMethod";
-  case GeV_to_Signal:	                 return "GeV_to_Signal";
   case Signal_to_GeV:                    return "Signal_to_GeV";
   case BeamCrossingAngle:                return "BeamCrossingAngle";
   case LumiInColName:                    return "LumiInColName";

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -461,3 +461,14 @@ GlobalMethodsClass::WeightingMethod_t GlobalMethodsClass::getMethod(std::string 
   }
   throw std::runtime_error("Unkown weighting method");
 }
+
+double GlobalMethodsClass::posWeight(double cellEngy, double totEngy, GlobalMethodsClass::WeightingMethod_t method,
+                                     double logWeightConstNow) {
+  if (method == GlobalMethodsClass::EnergyMethod)
+    return cellEngy;
+  // ???????? DECIDE/FIX - improve the log weight constants ????????
+  if (method == GlobalMethodsClass::LogMethod) {
+    return std::max(0.0, log(cellEngy / totEngy) + logWeightConstNow);
+  }
+  return -1;
+}

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -254,7 +254,7 @@ void GlobalMethodsClass::ThetaPhiCell(int cellId , std::map <GlobalMethodsClass:
   CellIdZPR(cellId, cellIdZ, cellIdPhi, cellIdR, arm);
 
   // theta
-  double rCell      = GlobalParamD[RMin] + (cellIdR + .5) * GlobalParamD[RCellLength];
+  double rCell      = GlobalParamD[RMin] + (cellIdR + 0.5) * GlobalParamD[RCellLength] - GlobalParamD[RCellOffset];
   double zCell      = fabs(GlobalParamD[ZStart]) + GlobalParamD[ZLayerThickness] * (cellIdZ) +  GlobalParamD[ZLayerZOffset];
   double thetaCell  = atan(rCell / zCell);
 
@@ -283,6 +283,7 @@ std::string GlobalMethodsClass::GetParameterName ( Parameter_t par ){
   case NumCellsPhi:	                 return "NumCellsPhi";
   case NumCellsZ:	                 return "NumCellsZ";
   case RCellLength:	                 return "RCellLength";
+  case RCellOffset:	                 return "RCellOffset";
   case PhiCellLength:	                 return "PhiCellLength";
   case ZLayerThickness:	                 return "ZLayerThickness";
   case ZLayerPhiOffset:	                 return "ZLayerPhiOffset";
@@ -352,6 +353,7 @@ void GlobalMethodsClass::SetGeometryGear() {
 
   // cell division numbers
   GlobalParamD[RCellLength]   = _lcalGearPars.getLayerLayout().getCellSize0(0);
+  GlobalParamD[RCellOffset]   = 0.0;
   GlobalParamD[PhiCellLength] = _lcalGearPars.getLayerLayout().getCellSize1(0);
   GlobalParamI[NumCellsR]   = (int)( (GlobalParamD[RMax]-GlobalParamD[RMin]) / GlobalParamD[RCellLength]);
   GlobalParamI[NumCellsPhi] = (int)(2.0 * M_PI / GlobalParamD[PhiCellLength] + 0.5);
@@ -362,6 +364,7 @@ void GlobalMethodsClass::SetGeometryGear() {
 
   // layer thickness
   GlobalParamD[ZLayerThickness] = _lcalGearPars.getLayerLayout().getThickness(0);
+  GlobalParamD[ZLayerZOffset]   = 0.0;
 }
 
 
@@ -391,6 +394,7 @@ bool GlobalMethodsClass::SetGeometryDD4HEP() {
   // cell division numbers
   typedef dd4hep::DDSegmentation::TypedSegmentationParameter< double > ParDou;
   ParDou* rPar = dynamic_cast<ParDou*>(readout.segmentation()->parameter("grid_size_r"));
+  ParDou* rOff = dynamic_cast<ParDou*>(readout.segmentation()->parameter("offset_r"));
   ParDou* pPar = dynamic_cast<ParDou*>(readout.segmentation()->parameter("grid_size_phi"));
 
   if (rPar == NULL or pPar == NULL ) {
@@ -398,6 +402,7 @@ bool GlobalMethodsClass::SetGeometryDD4HEP() {
   }
 
   GlobalParamD[RCellLength]   = rPar->typedValue()/dd4hep::mm;
+  GlobalParamD[RCellOffset]   = 0.5 * GlobalParamD[RCellLength] + GlobalParamD[RMin] - rOff->typedValue() / dd4hep::mm;
   GlobalParamD[PhiCellLength] = pPar->typedValue()/dd4hep::radian;
   GlobalParamI[NumCellsR]     = (int)( (GlobalParamD[RMax]-GlobalParamD[RMin]) / GlobalParamD[RCellLength]);
   GlobalParamI[NumCellsPhi]   = (int)(2.0 * M_PI / GlobalParamD[PhiCellLength] + 0.5);

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -37,10 +37,6 @@ bool convert(std::string input, T &value) {
  return ( ! (stream >> std::setbase(0) >> value).fail() ) && stream.eof();
 }
 
-GlobalMethodsClass::WeightingMethod_t GlobalMethodsClass::LogMethod = "LogMethod";
-GlobalMethodsClass::WeightingMethod_t GlobalMethodsClass::EnergyMethod = "EnergyMethod";
-double GlobalMethodsClass::EnergyCalibrationFactor = 0.0105;
-
 GlobalMethodsClass :: GlobalMethodsClass() :
   _procName( "MarlinLumiCalClusterer" ),
   _useDD4hep(false),
@@ -181,7 +177,7 @@ void GlobalMethodsClass::SetConstants( marlin::Processor* procPTR ) {
   val = ( val <= GlobalParamD[PhiCellLength] ) ? val : val*M_PI/180.;
   GlobalParamD[ZLayerPhiOffset] = val; 
 
-  EnergyCalibrationFactor = _lcalRecoPars->getFloatVal("EnergyCalibConst");
+  m_energyCalibrationFactor = _lcalRecoPars->getFloatVal("EnergyCalibConst");
 
   // logarithmic constant for position reconstruction
   GlobalParamD[LogWeightConstant] = _lcalRecoPars->getFloatVal("LogWeigthConstant");
@@ -237,11 +233,11 @@ double GlobalMethodsClass::SignalGevConversion( Parameter_t optName , double val
   //const double conversionFactor(0.0105);
 
   if(optName == GeV_to_Signal)
-    returnVal = valNow * EnergyCalibrationFactor;
+    returnVal = valNow * m_energyCalibrationFactor;
   //		returnVal = valNow * .0105 + .0013;
 
   if(optName == Signal_to_GeV)
-    returnVal = valNow / EnergyCalibrationFactor;
+    returnVal = valNow / m_energyCalibrationFactor;
   //		returnVal = (valNow-.0013) / .0105;
 
   return returnVal;
@@ -454,4 +450,14 @@ bool GlobalMethodsClass::SetGeometryDD4HEP() {
 #endif
   //no dd4hep geometry
   return false;
+}
+
+GlobalMethodsClass::WeightingMethod_t GlobalMethodsClass::getMethod(std::string const& methodName) const {
+  if (methodName == "LogMethod") {
+    return LogMethod;
+  }
+  if (methodName == "EnergyMethod") {
+    return EnergyMethod;
+  }
+  throw std::runtime_error("Unkown weighting method");
 }

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -420,10 +420,8 @@ bool GlobalMethodsClass::SetGeometryDD4HEP() {
     it->second.nominal().localToWorld( loc, glob );
     GlobalParamD[BeamCrossingAngle] = 2.0*fabs( atan( glob.x() / glob.z() ) / dd4hep::rad );
     if( glob.z() > 0.0 ) {
-      std::cout << " Forward "  << std::endl;
       _forwardCalo = &it->second.nominal().worldTransformation();
     } else {
-      std::cout << " Backward "  << std::endl;
       _backwardCalo = &it->second.nominal().worldTransformation();
 
       //get phi rotation from global to local transformation

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -58,3 +58,51 @@ std::ostream& operator<<(std::ostream & o, const LCCluster& rhs) {
     << "  pos(theta,phi) =  ( " << std::setw(10) << rhs._theta << " , " << std::setw(10) << rhs._phi << " )";
   return o;
 }
+
+/** recalculate the position of the cluster based on the theta and phi averages
+ *
+ * Resolution in Theta (R) is better than in RPhi so averaging theta gives better results
+ */
+void LCCluster::recalculatePositionFromHits(GlobalMethodsClass const& gmc) {
+  const double logConstant(gmc.GlobalParamD.at(GlobalMethodsClass::LogWeightConstant));
+
+  //re-set new cluster energy
+  _energy = 0.0;
+  for (auto const& calHit : _caloHits) {
+    _energy += calHit->getEnergy();
+  }
+
+  double thetaTemp(0.0), weightsTemp(0.0), xTemp(0.0), yTemp(0.0), zTemp(0.0);
+  for (auto const& calHit : _caloHits) {
+    const auto*  pos    = calHit->getPosition();
+    const double weight = GlobalMethodsClass::posWeight(calHit->getEnergy(), _energy, _method, logConstant);
+    if (not(weight > 0))
+      continue;
+
+    const double r     = sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
+    const double theta = atan(r / pos[2]);
+
+    thetaTemp += theta * weight;
+
+    xTemp += pos[0] * weight;
+    yTemp += pos[1] * weight;
+    zTemp += pos[2] * weight;
+
+    weightsTemp += weight;
+  }
+
+  xTemp /= weightsTemp;
+  yTemp /= weightsTemp;
+  zTemp /= weightsTemp;
+
+  thetaTemp /= weightsTemp;
+
+  _phi   = atan2(yTemp, xTemp);
+  _theta = thetaTemp;
+
+  const double r = sqrt(xTemp * xTemp + yTemp * yTemp + zTemp * zTemp);
+
+  _position[0] = r * sin(_theta) * cos(_phi);
+  _position[1] = r * sin(_theta) * sin(_phi);
+  _position[2] = r * cos(_theta);
+}

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -5,13 +5,19 @@
 #include <iomanip>
 
 LCCluster::LCCluster()
-    : _position{0.0, 0.0, 0.0}, _energy(0.0), _weight(0.0), _method("LogMethod"), _theta(0.0), _phi(0.0), _caloHits{} {}
+    : _position{0.0, 0.0, 0.0},
+      _energy(0.0),
+      _weight(0.0),
+      _method(GlobalMethodsClass::LogMethod),
+      _theta(0.0),
+      _phi(0.0),
+      _caloHits{} {}
 
 LCCluster::LCCluster(const VirtualCluster& vc)
     : _position{vc.getX(), vc.getY(), vc.getZ()},
       _energy(0.0),
       _weight(0.0),
-      _method("LogMethod"),
+      _method(GlobalMethodsClass::LogMethod),
       _theta(0.0),
       _phi(0.0),
       _caloHits{} {}
@@ -34,7 +40,7 @@ void LCCluster::clear() {
   _position[1] = 0.0;
   _position[2] = 0.0;
   _weight = 0.0;
-  _method = "";
+  _method      = GlobalMethodsClass::LogMethod;
   _theta = 0.0;
   _phi = 0.0;
   _caloHits.clear();

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -27,38 +27,43 @@ namespace EVENT{
 /* ============================================================================
    Constructor
    ========================================================================= */
-LumiCalClustererClass::LumiCalClustererClass(std::string const& lumiNameNow):
-  _superClusterIdToCellId(),
-  _superClusterIdToCellEngy(),
-  _superClusterIdClusterInfo(),
-  _lumiName( lumiNameNow ),
-  _clusterMinNumHits(15),
-  _hitMinEnergy(5*1e-6),
-  // global variables
-  _numEventsPerTree(0), _resetRootTrees(0),
-  _maxLayerToAnalyse(0),
-  _zFirstLayer(0), _zLayerThickness(0.0), _zLayerPhiOffset(0.0),
-  _rMin(0.0), _rMax(0.0), _rCellLength(0.0), _phiCellLength(0.0),
-  _beamCrossingAngle(0.),
-  _elementsPercentInShowerPeakLayer(0.03),
-  _logWeightConst(0.0),
-  _nNearNeighbor (6),
-  _cellRMax(0), _cellPhiMax (0),
-  _middleEnergyHitBoundFrac(0.01),
-  _methodCM("LogMethod"),
-  _moliereRadius(),
-  _thetaContainmentBounds(),
-  _minSeparationDistance(), _minClusterEngyGeV(), _minClusterEngySignal(),
-  _totEngyArm(),
-  _numHitsInArm(),
-  _mydecoder(),
-  _gmc(),
-  _useDD4hep(false),
-  RotMat()
-{
-}
-
-
+LumiCalClustererClass::LumiCalClustererClass(std::string const& lumiNameNow)
+    : _superClusterIdToCellId(),
+      _superClusterIdToCellEngy(),
+      _superClusterIdClusterInfo(),
+      _lumiName(lumiNameNow),
+      _clusterMinNumHits(15),
+      _hitMinEnergy(5 * 1e-6),
+      // global variables
+      _numEventsPerTree(0),
+      _resetRootTrees(0),
+      _maxLayerToAnalyse(0),
+      _zFirstLayer(0),
+      _zLayerThickness(0.0),
+      _zLayerPhiOffset(0.0),
+      _rMin(0.0),
+      _rMax(0.0),
+      _rCellLength(0.0),
+      _phiCellLength(0.0),
+      _beamCrossingAngle(0.),
+      _elementsPercentInShowerPeakLayer(0.03),
+      _logWeightConst(0.0),
+      _nNearNeighbor(6),
+      _cellRMax(0),
+      _cellPhiMax(0),
+      _middleEnergyHitBoundFrac(0.01),
+      _methodCM(GlobalMethodsClass::LogMethod),
+      _moliereRadius(),
+      _thetaContainmentBounds(),
+      _minSeparationDistance(),
+      _minClusterEngyGeV(),
+      _minClusterEngySignal(),
+      _totEngyArm(),
+      _numHitsInArm(),
+      _mydecoder(),
+      _gmc(),
+      _useDD4hep(false),
+      RotMat() {}
 
 /* ============================================================================
    initial action before first event analysis starts:
@@ -73,7 +78,7 @@ void LumiCalClustererClass::init( GlobalMethodsClass const& gmc ){
   _armsToCluster.push_back(-1);
   _armsToCluster.push_back(1);
      -------------------------------------------------------------------------- */
-  _methodCM				= gmc.GlobalParamS.at(GlobalMethodsClass::WeightingMethod); // GlobalMethodsClass::LogMethod
+  _methodCM = gmc.getMethod(gmc.GlobalParamS.at(GlobalMethodsClass::WeightingMethod));  // GlobalMethodsClass::LogMethod
   _clusterMinNumHits			= gmc.GlobalParamI.at(GlobalMethodsClass::ClusterMinNumHits); // = 15
   _hitMinEnergy				= gmc.GlobalParamD.at(GlobalMethodsClass::MinHitEnergy); // = 5e-6
   _zLayerThickness			= gmc.GlobalParamD.at(GlobalMethodsClass::ZLayerThickness); // = 4.5

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -57,7 +57,6 @@ LumiCalClustererClass::LumiCalClustererClass(std::string const& lumiNameNow)
       _thetaContainmentBounds(),
       _minSeparationDistance(),
       _minClusterEngyGeV(),
-      _minClusterEngySignal(),
       _totEngyArm(),
       _numHitsInArm(),
       _mydecoder(),
@@ -106,7 +105,6 @@ void LumiCalClustererClass::init( GlobalMethodsClass const& gmc ){
   // minimal separation distance and energy (of either cluster) to affect a merge
   _minSeparationDistance = gmc.GlobalParamD.at(GlobalMethodsClass::MinSeparationDist);
   _minClusterEngyGeV = gmc.GlobalParamD.at(GlobalMethodsClass::MinClusterEngyGeV);
-  _minClusterEngySignal = gmc.GlobalParamD.at(GlobalMethodsClass::MinClusterEngySignal);
 
 
   _thetaContainmentBounds[0] = gmc.GlobalParamD.at(GlobalMethodsClass::ThetaMin);
@@ -145,7 +143,6 @@ void LumiCalClustererClass::init( GlobalMethodsClass const& gmc ){
 			 << " _moliereRadius: "		            << _moliereRadius			 << std::endl
 			 << " _minSeparationDistance: "	            << _minSeparationDistance		 << std::endl
 			 << " _minClusterEngy - GeV: "	            << _minClusterEngyGeV		 << std::endl
-			 << " _minClusterEngy - Signal: "	    << _minClusterEngySignal             << std::endl
 			 << " _hitMinEnergy: "		            << _hitMinEnergy		         << std::endl
 			 << " _thetaContainmentBounds[0]: "	    << _thetaContainmentBounds[0]	 << std::endl
 			 << " _thetaContainmentBounds[1]: "	    << _thetaContainmentBounds[1]	 << std::endl

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -191,19 +191,14 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
     int armNow = _armsToCluster[armToClusterNow];
  */
   for(int armNow = -1; armNow < 2; armNow += 2) {
-#if _GENERAL_CLUSTERER_DEBUG == 1
-    streamlog_out( DEBUG ) << std::endl
+    streamlog_out(DEBUG6) << std::endl
 	      << "ARM = " << armNow << " : " << std::endl << std::endl;
-#endif
     /* --------------------------------------------------------------------------
        Construct clusters for each arm
        -------------------------------------------------------------------------- */
-#if _CLUSTER_BUILD_DEBUG == 1
-    streamlog_out(DEBUG2) << "\tRun LumiCalClustererClass::buildClusters()" << std::endl;
-    streamlog_out(DEBUG2) << "\tEnergy deposit: "<< _totEngyArm[-1] << "\t" << _totEngyArm[1] <<"\n"
-			  << "\tNumber of hits: "<< _numHitsInArm[-1] << "\t" << _numHitsInArm[1] << "\n\n";
-#endif
-
+    streamlog_out(DEBUG6) << "\tRun LumiCalClustererClass::buildClusters()" << std::endl;
+    streamlog_out(DEBUG5) << "\tEnergy deposit: "<< _totEngyArm[-1] << "\t" << _totEngyArm[1] <<"\n"
+			  << "\tNumber of hits: "<< _numHitsInArm[-1] << "\t" << _numHitsInArm[1] << std::endl;
     buildClusters( calHits[armNow],
 		   calHitsCellIdGlobal[armNow],
 		   _superClusterIdToCellId[armNow],
@@ -215,10 +210,7 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
     /* --------------------------------------------------------------------------
        Merge superClusters according the minDistance nad minEngy rules
        -------------------------------------------------------------------------- */
-#if _GENERAL_CLUSTERER_DEBUG == 1
-    streamlog_out( DEBUG ) << "\tRun LumiCalClustererClass::clusterMerger()" << std::endl;
-#endif
-
+    streamlog_out(DEBUG6) << "\tRun LumiCalClustererClass::clusterMerger()" << std::endl;
     clusterMerger(		_superClusterIdToCellEngy[armNow],
 				_superClusterIdToCellId[armNow],
 				superClusterCM[armNow],
@@ -228,6 +220,7 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
     /* --------------------------------------------------------------------------
        Perform fiducial volume cuts
        -------------------------------------------------------------------------- */
+    streamlog_out(DEBUG6) << "\tRun LumiCalClustererClass::fiducialVolumeCuts()" << std::endl;
     fiducialVolumeCuts(		_superClusterIdToCellId[armNow],
 				_superClusterIdToCellEngy[armNow],
 				superClusterCM[armNow] );
@@ -238,10 +231,7 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
        -------------------------------------------------------------------------- */
 #if _CLUSTER_MIXING_ENERGY_CORRECTIONS == 1
     if(superClusterCM[armNow].size() == 2) {
-#if _GENERAL_CLUSTERER_DEBUG == 1
-      streamlog_out( DEBUG ) << "\tRun LumiCalClustererClass::energyCorrections()" << std::endl;
-#endif
-
+      streamlog_out(DEBUG6) << "Run LumiCalClustererClass::energyCorrections()" << std::endl;
       energyCorrections( _superClusterIdToCellId[armNow],
 			 _superClusterIdToCellEngy[armNow],
 			 superClusterCM[armNow],
@@ -255,22 +245,16 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
   /* --------------------------------------------------------------------------
      verbosity
      -------------------------------------------------------------------------- */
-#if _GENERAL_CLUSTERER_DEBUG == 1
-  streamlog_out( DEBUG4 ) << "Final clusters:" << std::endl;
-#endif
- for(int armNow = -1; armNow < 2; armNow += 2) {
-     for(MapIntLCCluster::iterator superClusterCMIterator = superClusterCM[armNow].begin();
-	superClusterCMIterator != superClusterCM[armNow].end();
-	++superClusterCMIterator) {
+  streamlog_out(DEBUG6) << "Final clusters:" << std::endl;
+  for (int armNow = -1; armNow < 2; armNow += 2) {
+    for (MapIntLCCluster::iterator superClusterCMIterator = superClusterCM[armNow].begin();
+         superClusterCMIterator != superClusterCM[armNow].end(); ++superClusterCMIterator) {
       const int superClusterId = (int)superClusterCMIterator->first;
 
-#if _GENERAL_CLUSTERER_DEBUG == 1
-      streamlog_out( DEBUG4 ) << "  Arm:"    << std::setw(4)  << armNow
-			     << "  Id:"     << std::setw(4)  << superClusterId
-			     << superClusterCMIterator->second
-			     << std::endl;
-#endif
-      //Store information of clusters
+      streamlog_out(DEBUG6) << "  Arm:"    << std::setw(4) << armNow
+                            << "  Id:"     << std::setw(4) << superClusterId
+                            << superClusterCMIterator->second
+                            << std::endl;
       _superClusterIdClusterInfo[armNow][superClusterId] = superClusterCMIterator->second;
     }
   }

--- a/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
@@ -16,70 +16,15 @@ using LCHelper::distance2D;
 #include <DD4hep/DD4hepUnits.h>
 #endif
 
-
-
 /* --------------------------------------------------------------------------
    calculate weight for cluster CM according to different methods
-   -------------------------------------------------------------------------- */
-template <> double LumiCalClustererClass::posWeight(CalHit const& calHit, GlobalMethodsClass::WeightingMethod_t method) {
-  double posWeightHit = -1.;
-
-  if( method == GlobalMethodsClass::EnergyMethod ) {
- 
-      return ( calHit->getEnergy() ) ;
-
-  }else if (method == GlobalMethodsClass::LogMethod)  {            // ???????? DECIDE/FIX - improve the log weight constants ????????
-
-    int	detectorArm = ((calHit->getPosition()[2] < 0) ? -1 : 1 );
-    posWeightHit = log(calHit->getEnergy() / _totEngyArm[detectorArm]) + _logWeightConst;
-    if(posWeightHit < 0) posWeightHit = 0. ;
-    return posWeightHit;
-
-  }
-  return posWeightHit;
-}
-
-/* --------------------------------------------------------------------------
-   calculate weight for cluster CM according to different methods
+   - provide cellEnergy to use
    -------------------------------------------------------------------------- */
 template <>
 double LumiCalClustererClass::posWeightTrueCluster(CalHit const& calHit, double cellEngy,
-                                                   GlobalMethodsClass::WeightingMethod_t method) {
-  double	posWeightHit = 0.;
+                                                   GlobalMethodsClass::WeightingMethod_t method) const {
   int	detectorArm = ((calHit->getPosition()[2] < 0) ? -1 : 1 );
-
-  if(method == GlobalMethodsClass::EnergyMethod) posWeightHit = cellEngy;
-
-
-  // ???????? DECIDE/FIX - improve the log weight constants ????????
-  if(method == GlobalMethodsClass::LogMethod) {
-    posWeightHit = log(cellEngy / _totEngyArm[detectorArm]) + _logWeightConst;
-
-    if(posWeightHit < 0) posWeightHit = 0. ;
-  }
-
-  return posWeightHit;
-}
-
-/* --------------------------------------------------------------------------
-   calculate weight for cluster CM according to different methods
-   - overloaded version with a given energy normalization
-   -------------------------------------------------------------------------- */
-template <>
-double LumiCalClustererClass::posWeight(CalHit const& calHit, double totEngy, GlobalMethodsClass::WeightingMethod_t method) {
-  double	posWeightHit = 0.;
-
-  if(method == GlobalMethodsClass::EnergyMethod) posWeightHit = calHit->getEnergy();
-
-
-  // ???????? DECIDE/FIX - improve the log weight constants ????????
-  if(method == GlobalMethodsClass::LogMethod) {
-    posWeightHit = log(calHit->getEnergy() / totEngy) + _logWeightConst;
-
-    if(posWeightHit < 0) posWeightHit = 0. ;
-  }
-
-  return posWeightHit;
+  return GlobalMethodsClass::posWeight(cellEngy, _totEngyArm.at(detectorArm), method, _logWeightConst);
 }
 
 /* --------------------------------------------------------------------------
@@ -88,20 +33,26 @@ double LumiCalClustererClass::posWeight(CalHit const& calHit, double totEngy, Gl
    -------------------------------------------------------------------------- */
 template <>
 double LumiCalClustererClass::posWeight(CalHit const& calHit, double totEngy, GlobalMethodsClass::WeightingMethod_t method,
-                                        double logWeightConstNow) {
-  double	posWeightHit = 0.;
+                                        double logWeightConstNow) const {
+  return GlobalMethodsClass::posWeight(calHit->getEnergy(), totEngy, method, logWeightConstNow);
+}
 
-  if(method == GlobalMethodsClass::EnergyMethod ) posWeightHit = calHit->getEnergy();
+/* --------------------------------------------------------------------------
+   calculate weight for cluster CM according to different methods
+   -------------------------------------------------------------------------- */
+template <>
+double LumiCalClustererClass::posWeight(CalHit const& calHit, GlobalMethodsClass::WeightingMethod_t method) const {
+  return posWeightTrueCluster(calHit, calHit->getEnergy(), method);
+}
 
-
-  // ???????? DECIDE/FIX - improve the log weight constants ????????
-  if(method == GlobalMethodsClass::LogMethod ) {
-    posWeightHit = log(calHit->getEnergy() / totEngy) + logWeightConstNow;
-
-    if(posWeightHit < 0) posWeightHit = 0. ;
-  }
-
-  return posWeightHit;
+/* --------------------------------------------------------------------------
+   calculate weight for cluster CM according to different methods
+   - overloaded version with a given energy normalization
+   -------------------------------------------------------------------------- */
+template <>
+double LumiCalClustererClass::posWeight(CalHit const& calHit, double totEngy,
+                                        GlobalMethodsClass::WeightingMethod_t method) const {
+  return GlobalMethodsClass::posWeight(calHit->getEnergy(), totEngy, method, _logWeightConst);
 }
 
 /* --------------------------------------------------------------------------

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -168,14 +168,16 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
 			   << "Number of hits: "<< _numHitsInArm[-1] << "\t" << _numHitsInArm[1] << "\n\n";
 #endif
 
-    if(    (( _numHitsInArm[-1] < _clusterMinNumHits) || (_totEngyArm[-1] < _minClusterEngySignal))
-	   && (( _numHitsInArm[ 1] < _clusterMinNumHits) || (_totEngyArm[ 1] < _minClusterEngySignal)) ){
+    if (((_numHitsInArm[-1] < _clusterMinNumHits) || (_totEngyArm[-1] < _minClusterEngyGeV)) &&
+        ((_numHitsInArm[1] < _clusterMinNumHits) || (_totEngyArm[1] < _minClusterEngyGeV))) {
       return 0;
     }else{ return 1; }
 }
 
 LCCollection* LumiCalClustererClass::createCaloHitCollection(LCCollection* simCaloHitCollection) const {
   streamlog_out(MESSAGE) << "Creating the CalorimeterHit collection with dummy digitization" << std::endl;
+
+  const double calibrationFactor = _gmc.getCalibrationFactor();
 
   auto caloHitCollection = new IMPL::LCCollectionVec(LCIO::CALORIMETERHIT);
   caloHitCollection->parameters().setValue(LCIO::CellIDEncoding,
@@ -187,7 +189,7 @@ LCCollection* LumiCalClustererClass::createCaloHitCollection(LCCollection* simCa
 
     calHit->setCellID0(simHit->getCellID0());
     calHit->setCellID1(simHit->getCellID1());
-    calHit->setEnergy(simHit->getEnergy());
+    calHit->setEnergy(simHit->getEnergy() * calibrationFactor);
     calHit->setPosition(simHit->getPosition());
 
     caloHitCollection->addElement(calHit);

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -87,8 +87,9 @@ std::map < int , double > snbx;
           LCCluster& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
           thisClusterInfo.recalculatePositionFromHits(gmc);
 
-	  const double clusterEnergy = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV , thisClusterInfo.getE());
-	  if( clusterEnergy < _minClusterEngy ) continue;
+          const double clusterEnergy = thisClusterInfo.getE();
+          if (clusterEnergy < _minClusterEngy)
+            continue;
 
           if( _cutOnFiducialVolume ) {
             const double clusterTheta = thisClusterInfo.getTheta();
@@ -170,8 +171,7 @@ std::map < int , double > snbx;
 	     ++mapIntClusterClassIt) {
 
 	  ClusterClass* thisCluster = mapIntClusterClassIt->second;
-	  const double engyNow  = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV,
-							  thisCluster->Engy);
+	  const double engyNow  = thisCluster->Engy;
 	  const double thetaNow = thisCluster -> Theta;
 	  // highest energy RecoParticle
 	  if(thisCluster->HighestEnergyFlag == 1){
@@ -224,8 +224,7 @@ std::map < int , double > snbx;
 	  //	  if(thisCluster->HighestEnergyFlag == 0)	continue;
 	  clusterInFlag++;
 
-	  const double engyNow = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV,
-							 thisCluster -> Engy);
+	  const double engyNow = thisCluster -> Engy;
 	  const double thetaNow = thisCluster -> Theta;
 	  const double phiNow   = thisCluster -> Phi;
 	  const double rzstartNow = thisCluster -> RZStart;
@@ -435,7 +434,7 @@ std::map < int , double > snbx;
 	    const int clusterId = mapIntClusterClassIt->first;
 	    ClusterClass* thisCluster = mapIntClusterClassIt->second;
 
-	    double eneCL = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV ,thisCluster -> Engy);
+	    double eneCL = thisCluster->Engy;
 	    double phiCL = thisCluster -> Phi;
 	    double RZStart = thisCluster -> RZStart;
 	    double xs = RZStart*cos(phiCL);
@@ -489,7 +488,7 @@ std::map < int , double > snbx;
 	    }
 
 	    if( thisCluster -> Pdg != 0) {
-	      double Ereco = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV ,thisCluster -> Engy);
+	      double Ereco = thisCluster->Engy;
 	      streamlog_out( MESSAGE4 ) << "\tParticle Out ("
 		  << thisCluster -> OutsideReason << "):   " << clusterId << std::endl
 		  << "\t\t side(arm), pdg, parentId , NumMCDaughters = "

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -325,19 +325,15 @@ std::map < int , double > snbx;
     std::vector < MCInfo > mcParticlesVecPos;
     std::vector < MCInfo > mcParticlesVecNeg;
 
-#if _CREATE_CLUSTERS_DEBUG == 1
-	streamlog_out(MESSAGE4) << "CreateClusters: event = " << evt-> getEventNumber() << std::endl;
-#endif
+    streamlog_out(DEBUG7) << "CreateClusters: event = " << evt->getEventNumber()<< std::endl;
     LCCollection * particles = evt->getCollection( "MCParticle" );
     if ( particles ){
       int numMCParticles = particles->getNumberOfElements();
-#if _CREATE_CLUSTERS_DEBUG == 1
-      if( numMCParticles ){
-	streamlog_out(MESSAGE4) << "CreateClusters: numMCParticles = " << numMCParticles  << std::endl;
+      if(numMCParticles){
+	streamlog_out(DEBUG6) << "CreateClusters: numMCParticles = " << numMCParticles << std::endl;
       }else{
-	streamlog_out(MESSAGE4) << "CreateClusters: No MCparticles in this event !" << std::endl;
+	streamlog_out(DEBUG6) << "CreateClusters: No MCparticles in this event !" << std::endl;
       }
-#endif
       for ( int jparticle=0; jparticle<numMCParticles; jparticle++ ){
 	MCParticle * particle = static_cast<MCParticle*>( particles->getElementAt(jparticle) );
 	MCInfo p = MCInfo::getMCParticleInfo( particle, gmc );
@@ -352,10 +348,10 @@ std::map < int , double > snbx;
     int numOfClustersPos =  clusterIdToCellId.at(1).size();
 #if _CREATE_CLUSTERS_DEBUG == 1
     if( numOfClustersNeg || numOfClustersPos ){
-      streamlog_out(MESSAGE) << "Initial Set Stats for LumiCal......."<< std::endl;
-      streamlog_out(MESSAGE) << "     numOfClusters arm[-1] = "<< numOfClustersNeg << "\t arm[1] = "<< numOfClustersPos << std::endl;
+      streamlog_out(DEBUG6) << "Initial Set Stats for LumiCal......."<< std::endl;
+      streamlog_out(DEBUG6) << "     numOfClusters arm[-1] = "<< numOfClustersNeg << "\t arm[1] = "<< numOfClustersPos << std::endl;
     }else{
-      streamlog_out(MESSAGE) << "Initial Set Stats for LumiCal: No clusters found in this event !"<< std::endl;
+      streamlog_out(DEBUG6) << "Initial Set Stats for LumiCal: No clusters found in this event !"<< std::endl;
     }
 #endif
     if( numOfClustersNeg || numOfClustersPos ){ 
@@ -389,7 +385,7 @@ std::map < int , double > snbx;
 	  thisCluster->ResetStats(); // calculate energy, position for the cluster
 	
 	  LCCluster const& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
-	  streamlog_out(DEBUG3) << "arm =   " << armNow <<"\t cluster "<< clusterId<< "  ...... " << std::endl
+	  streamlog_out(DEBUG6) << "arm =   " << armNow <<"\t cluster "<< clusterId<< "  ...... " << std::endl
 				<< std::setw(20) << "X, Y, Z:" << std::endl
 				<< std::setw(20) << "ClusterClass"
 				<< std::fixed << std::setprecision(3)

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -82,12 +82,10 @@ std::map < int , double > snbx;
 			     << "\t Number of clusters: "<< LumiCalClusterer._superClusterIdToCellId[armNow].size()
 			     <<std::endl;
 
-	for( MapIntVInt::const_iterator clusterIdToCellIdIterator = LumiCalClusterer._superClusterIdToCellId[armNow].begin();
-	     clusterIdToCellIdIterator != LumiCalClusterer._superClusterIdToCellId[armNow].end();
-	     clusterIdToCellIdIterator++) {
-	  const int clusterId = clusterIdToCellIdIterator->first;
-
-	  LCCluster const& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
+        for (auto const& pairIDCells : LumiCalClusterer._superClusterIdToCellId[armNow]) {
+          const int  clusterId       = pairIDCells.first;
+          LCCluster& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
+          thisClusterInfo.recalculatePositionFromHits(gmc);
 
 	  const double clusterEnergy = gmc.SignalGevConversion(GlobalMethodsClass::Signal_to_GeV , thisClusterInfo.getE());
 	  if( clusterEnergy < _minClusterEngy ) continue;


### PR DESCRIPTION

BEGINRELEASENOTES
- LumiCalReco: base all calculations on calibrated hits, allows "external" calibration
- LumiCalReco: correct the cluster position calculation for optimal theta resolutions, ensure consistency between theta calculation and cluster position (x,y,z). Theta calculation for theta in the rootOutput was correct, the theta for SLCIO output is now much better reconstructed.
- LumiCalReco: add RCellOffset to calculate radial cell coordinate for DD4hep segmentation, automatically derived from segmentation (affected the ROOT output for Theta)
- LumiCalReco: re-factoring for weight calculations, cleanup, debug outputs

ENDRELEASENOTES