### PR TITLE
More Position Fixes, scale weights by radius

### DIFF
--- a/source/LumiCalReco/include/ClusterClass.h
+++ b/source/LumiCalReco/include/ClusterClass.h
@@ -2,6 +2,8 @@
 #define ClusterClass_h 1
 
 #include "GlobalMethodsClass.h"
+#include "LCCluster.hh"
+#include "MCInfo.h"
 
 #include <map>
 #include <string>
@@ -17,37 +19,50 @@ namespace EVENT {
 class ClusterClass {
 
 public:
-  ClusterClass(GlobalMethodsClass& gmc, int idNow, int armNow, VInt const& cells, VDouble const& cellEnergies);
+  ClusterClass(GlobalMethodsClass& gmc, int idNow, LCCluster const* clusterInfo);
   ~ClusterClass() = default;
+  ClusterClass(const ClusterClass&) = default;
+  ClusterClass& operator=(const ClusterClass&) = default;
 
   void	FillHit(int cellNow, double engyNow);
   int	ResetStats();
-  void	SetStatsMC(EVENT::MCParticle * mcParticle);
+  void SetStatsMC(SMCInfo const& mcParticle);
   void	SetStatsMC();
   void  PrintInfo();
 
-  int   	Id, Pdg, SignMC, ParentId, NumMCDaughters;
-  int   	OutsideFlag, MatchFlag, HighestEnergyFlag, ModifiedFlag;
-  int           NumHits;
-  double	Engy, Theta, Phi, RZStart;
-  double	VtxX, VtxY, VtxZ, EndPointX, EndPointY, EndPointZ;
-  double	EngyMC, ThetaMC, PhiMC;
-  double        DiffTheta, DiffPosXY;
-  double        clusterPosition[3];           // cluster position at Zbeg
-  double        mcpPosition[3];               // MCparticle position at Zbeg
+private:
+  LCCluster const* m_clusterInfo;
+  SMCInfo          m_mcInfo = std::make_shared<MCInfo>();
 
-  std::vector <int> MergedV;
+public:
+  int         Id        = 0;
+  double      DiffTheta = 0.0, DiffPosXY = 0.0;
+  int         OutsideFlag = 0, HighestEnergyFlag = 0;
+  std::string OutsideReason{};
 
-  std::string	OutsideReason;
+  const double* getPosition() const { return m_clusterInfo->getPosition(); }
+  const double* getPositionAtFront() const { return m_clusterInfo->getPositionAtFront(); }
 
-  std::map < int , double >	Hit;
+  const double* getMCPosition() const { return m_mcInfo->mcPosition; }
 
-  const double * getPosition() const { return clusterPosition; }
-  
   friend std::ostream& operator<<(std::ostream & o, const ClusterClass& rhs);
   
   GlobalMethodsClass& gmc;
 
+  double getEnergy() const { return m_clusterInfo->getEnergy(); }
+  double getTheta() const { return m_clusterInfo->getTheta(); }
+  double getPhi() const { return m_clusterInfo->getPhi(); }
+  double getRZStart() const { return m_clusterInfo->getRZStart(); }
+  int    getNHits() const { return m_clusterInfo->getCaloHits().size(); }
+
+  double getEnergyMC() const { return m_mcInfo->engy; }
+  double getThetaMC() const { return m_mcInfo->theta; }
+  double getPhiMC() const { return m_mcInfo->phi; }
+
+  int getPDG() const { return m_mcInfo->pdg; }
+  int getSign() const { return m_mcInfo->sign; }
+  int getParentId() const { return m_mcInfo->m_parentID; }
+  int getNumMCDaughters() const { return m_mcInfo->m_numMCDaughters; }
 };
 
 #endif // ClusterClass_h

--- a/source/LumiCalReco/include/ClusterClass.h
+++ b/source/LumiCalReco/include/ClusterClass.h
@@ -17,8 +17,8 @@ namespace EVENT {
 class ClusterClass {
 
 public:
-  ClusterClass(int idNow, GlobalMethodsClass& gmc);
-  ~ClusterClass();
+  ClusterClass(GlobalMethodsClass& gmc, int idNow, int armNow, VInt const& cells, VDouble const& cellEnergies);
+  ~ClusterClass() = default;
 
   void	FillHit(int cellNow, double engyNow);
   int	ResetStats();

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -29,7 +29,7 @@ private:
 public:
   enum WeightingMethod_t { LogMethod = -1, EnergyMethod = 1 };
 
-  enum Parameter_t{
+  enum Parameter_t {
     ZStart,
     ZEnd,
     RMin,
@@ -40,6 +40,7 @@ public:
     RCellLength,
     RCellOffset,
     PhiCellLength,
+    PhiCellOffset,
     ZLayerThickness,
     ZLayerPhiOffset,
     ZLayerZOffset,
@@ -60,7 +61,7 @@ public:
     LumiInColName,
     BetaGamma,
     Gamma
-};
+  };
   //
   
  enum Coordinate_t {

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -114,6 +114,7 @@ public:
   inline double getCalibrationFactor() const { return GlobalParamD.at(Signal_to_GeV); }
 
   template <class T, class U> inline void rotateToGlobal(const T* loc, U* glob) const;
+  template <class T, class U> inline void rotateToLumiCal(const T* glob, U* loc) const;
 
 private:
   void SetGeometryGear();
@@ -132,6 +133,13 @@ template <class T, class U> void GlobalMethodsClass::rotateToGlobal(const T* loc
   glob[0]          = +m_armCosAngle.at(armNow) * loc[0] + m_armSinAngle.at(armNow) * loc[2];
   glob[1]          = loc[1];
   glob[2]          = -m_armSinAngle.at(armNow) * loc[0] + m_armCosAngle.at(armNow) * loc[2];
+}
+
+template <class T, class U> void GlobalMethodsClass::rotateToLumiCal(const T* glob, U* loc) const {
+  const int armNow = (glob[2] < 0) ? -1 : 1;
+  loc[0]           = +m_armCosAngle.at(armNow) * glob[0] - m_armSinAngle.at(armNow) * glob[2];
+  loc[1]           = glob[1];
+  loc[2]           = +m_armSinAngle.at(armNow) * glob[0] + m_armCosAngle.at(armNow) * glob[2];
 }
 
 #endif

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -24,7 +24,6 @@ class TGeoHMatrix;
 
 class GlobalMethodsClass {
 private:
-  std::string _procName;
   bool _useDD4hep;
 
 public:
@@ -80,9 +79,8 @@ public:
   typedef std::map < Parameter_t, std::string > ParametersString;
 
   GlobalMethodsClass();
-  GlobalMethodsClass( const std::string &procType );
-  GlobalMethodsClass( const GlobalMethodsClass &rhs );
-  GlobalMethodsClass& operator=( const GlobalMethodsClass &rhs );
+  GlobalMethodsClass(const GlobalMethodsClass& rhs) = delete;
+  GlobalMethodsClass& operator=(const GlobalMethodsClass& rhs) = default;
 
   virtual ~GlobalMethodsClass();
  
@@ -114,6 +112,8 @@ public:
 
   inline double getCalibrationFactor() const { return GlobalParamD.at(Signal_to_GeV); }
 
+  template <class T, class U> inline void rotateToGlobal(const T* loc, U* glob) const;
+
 private:
   void SetGeometryGear();
   bool SetGeometryDD4HEP();
@@ -121,8 +121,16 @@ private:
   const TGeoHMatrix *_forwardCalo;
   const TGeoHMatrix *_backwardCalo;
 
+  // LumiCal rotations angles ( local->Global )
+  std::map<int, double> m_armCosAngle{};
+  std::map<int, double> m_armSinAngle{};
 };
 
-
+template <class T, class U> void GlobalMethodsClass::rotateToGlobal(const T* loc, U* glob) const {
+  const int armNow = (loc[2] < 0) ? -1 : 1;
+  glob[0]          = +m_armCosAngle.at(armNow) * loc[0] + m_armSinAngle.at(armNow) * loc[2];
+  glob[1]          = loc[1];
+  glob[2]          = -m_armSinAngle.at(armNow) * loc[0] + m_armCosAngle.at(armNow) * loc[2];
+}
 
 #endif

--- a/source/LumiCalReco/include/LCCluster.hh
+++ b/source/LumiCalReco/include/LCCluster.hh
@@ -32,8 +32,10 @@ public:
   inline double getEnergy() const { return getE(); }
   inline double getTheta() const { return _theta; }
   inline double getPhi() const { return _phi; }
+  inline double getRZStart() const { return _rzStart; }
 
   inline const double * getPosition() const { return _position; }
+  inline const double * getPositionAtFront() const { return _positionAtFront; }
 
   inline void setX( double x) { _position[0] = x; CalculatePhi(); }
   inline void setY( double y) { _position[1] = y; CalculatePhi(); }
@@ -57,11 +59,12 @@ private:
 
   void CalculatePhi();
   void CalculateTheta();
-  double _position[3];
-  double _energy, _weight;
-  GlobalMethodsClass::WeightingMethod_t _method;
-  double _theta, _phi;
-  VecCalHit _caloHits;
+  double _position[3]={0.0, 0.0, 0.0};
+  double _positionAtFront[3]={0.0, 0.0, 0.0};
+  double _energy=0.0, _weight=0.0;
+  GlobalMethodsClass::WeightingMethod_t _method=GlobalMethodsClass::LogMethod;
+  double _theta=0.0, _phi=0.0, _rzStart=0.0;
+  VecCalHit _caloHits{};
 
 };
 
@@ -75,5 +78,6 @@ inline void LCCluster::CalculateTheta() {
   return;
 }
 
+using SLCCluster = std::shared_ptr<LCCluster>;
 
 #endif // LCCluster_hh

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -195,9 +195,6 @@ protected:
   double	distance2DPolar( double * pos1,
 				 double * pos2 );
 
-  double	thetaPhiCell( int	cellId,
-			      GlobalMethodsClass::Coordinate_t	output );
-
   LCCluster calculateEngyPosCM( VInt const& cellIdV,
 				MapIntCalHit const& calHitsCellId,
 				GlobalMethodsClass::WeightingMethod_t method );

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -99,9 +99,6 @@ protected:
   bool _useDD4hep;
   bool _cutOnFiducialVolume=false;
 
-  // global to local rotations mtx elements
-  std::map < int , std::map< std::string, double> > RotMat;
-
   // methods:
   int	getCalHits( EVENT::LCEvent * evt,
 		    MapIntMapIntVCalHit & calHits );

--- a/source/LumiCalReco/include/MCInfo.h
+++ b/source/LumiCalReco/include/MCInfo.h
@@ -2,6 +2,7 @@
 #define MCInfo_h 1
 
 #include <cstddef>
+#include <memory>
 #include <ostream>
 
 class GlobalMethodsClass;
@@ -9,38 +10,38 @@ namespace EVENT{
   class MCParticle;
 }
 
+class MCInfo;
+
+using SMCInfo = std::shared_ptr<MCInfo>;
+
 class MCInfo{
 public:
-  EVENT::MCParticle* mcp;
-  double engy;
-  double theta;
-  double phi;
-  double x;
-  double y;
-  int pdg;
-  int sign;
-  double pp[3];
+  EVENT::MCParticle* mcp           = nullptr;
+  double             engy          = 0.0;
+  double             theta         = 0.0;
+  double             phi           = 0.0;
+  int                pdg           = 0;
+  int                sign          = 0;
+  double             pp[3]         = {0.0, 0.0, 0.0};
+  double             mcPosition[3] = {0.0, 0.0, 0.0};  /// position at LumiCal Front Face
 
-  MCInfo(): mcp(NULL), engy(0.0), theta(0.0), phi(0.0),
-	    x(0.0), y(0.0), pdg(0), sign(0) {
-    pp[0] = 0.0;
-    pp[1] = 0.0;
-    pp[2] = 0.0;
-  }
+  int m_id             = 0;
+  int m_parentID       = 0;
+  int m_numMCDaughters = 0;
 
-  MCInfo( EVENT::MCParticle *m, double e, double t, double p,
-	  double X, double Y, int P, int S):
-    mcp(m), engy(e), theta(t), phi(p), x(X), y(Y), pdg(P), sign(S) {
-    pp[0] = 0.0;
-    pp[1] = 0.0;
-    pp[2] = 0.0;
-  }
+  double m_vtxX = 0.0, m_vtxY = 0.0, m_vtxZ = 0.0, m_endX = 0.0, m_endY = 0.0, m_endZ = 0.0;
 
-  static MCInfo getMCParticleInfo( EVENT::MCParticle *particle, GlobalMethodsClass& gmc);
+  MCInfo() {}
 
-  friend std::ostream& operator<<(std::ostream & o, const MCInfo& rhs);
+  MCInfo(EVENT::MCParticle* m, double e, double t, double p, double X, double Y, double Z, int P, int S)
+      : mcp(m), engy(e), theta(t), phi(p), pdg(P), sign(S), mcPosition{X, Y, Z} {}
 
+  static SMCInfo getMCParticleInfo(EVENT::MCParticle* particle, GlobalMethodsClass& gmc);
 
+  friend std::ostream& operator<<(std::ostream& o, const MCInfo& rhs);
+
+  double x() const { return mcPosition[0]; }
+  double y() const { return mcPosition[1]; }
 };
 
 

--- a/source/LumiCalReco/include/MarlinLumiCalClusterer.h
+++ b/source/LumiCalReco/include/MarlinLumiCalClusterer.h
@@ -89,11 +89,7 @@ typedef std::map < int , std::vector<int> >  MapIntVInt;
 
     void TryMarlinLumiCalClusterer(EVENT::LCEvent * evt);
 
-    void CreateClusters( std::map < int , std::map < int , std::vector<int> > > const& clusterIdToCellId,
-			 std::map < int , std::map < int , std::vector<double> > > const& cellIdToCellEngy,
-			 //			 std::map < int , std::map < int , LCCluster > > const& superClusterIdClusterInfo,
-			 std::map < int , MapIntPClusterClass > & clusterClassMapP,
-			 EVENT::LCEvent * evt);
+    void CreateClusters(std::map<int, MapIntPClusterClass>& clusterClassMapP, EVENT::LCEvent* evt);
     std::tuple<ClusterImpl*, ReconstructedParticleImpl*> getLCIOObjects(LCCluster const& clusterInfo) const;
     void writeRootInfo(EVENT::LCEvent* evt);
 

--- a/source/LumiCalReco/include/MarlinLumiCalClusterer.h
+++ b/source/LumiCalReco/include/MarlinLumiCalClusterer.h
@@ -95,6 +95,7 @@ typedef std::map < int , std::vector<int> >  MapIntVInt;
 			 std::map < int , MapIntPClusterClass > & clusterClassMapP,
 			 EVENT::LCEvent * evt);
     std::tuple<ClusterImpl*, ReconstructedParticleImpl*> getLCIOObjects(LCCluster const& clusterInfo) const;
+    void writeRootInfo(EVENT::LCEvent* evt);
 
     inline double sqr( double a){ return a*a;};
     inline float sqr( float a){ return a*a;};

--- a/source/LumiCalReco/include/MarlinLumiCalClusterer.h
+++ b/source/LumiCalReco/include/MarlinLumiCalClusterer.h
@@ -16,6 +16,11 @@ namespace EVENT{
   class LCEvent;
 }
 
+namespace IMPL {
+  class ClusterImpl;
+  class ReconstructedParticleImpl;
+}
+
 typedef std::map < int , ClusterClass * > MapIntPClusterClass;
 typedef std::map < int , std::vector<int> >  MapIntVInt;
 
@@ -89,6 +94,7 @@ typedef std::map < int , std::vector<int> >  MapIntVInt;
 			 //			 std::map < int , std::map < int , LCCluster > > const& superClusterIdClusterInfo,
 			 std::map < int , MapIntPClusterClass > & clusterClassMapP,
 			 EVENT::LCEvent * evt);
+    std::tuple<ClusterImpl*, ReconstructedParticleImpl*> getLCIOObjects(LCCluster const& clusterInfo) const;
 
     inline double sqr( double a){ return a*a;};
     inline float sqr( float a){ return a*a;};

--- a/source/LumiCalReco/src/ClusterClass.cpp
+++ b/source/LumiCalReco/src/ClusterClass.cpp
@@ -16,28 +16,49 @@ using namespace streamlog;
 /* --------------------------------------------------------------------------
    This class holds information about the clusters
    -------------------------------------------------------------------------- */
-ClusterClass::ClusterClass(int idNow, GlobalMethodsClass& _gmc):
-  Id(idNow), Pdg(0), SignMC(0), ParentId(-1), NumMCDaughters(0),
-  OutsideFlag(0), MatchFlag(0), HighestEnergyFlag(0), ModifiedFlag(0),NumHits(0),
-  Engy(0.0), Theta(0.0), Phi(0.0), RZStart(0.0),
-  VtxX(0.0), VtxY(0.0), VtxZ(0.0), EndPointX(0.0), EndPointY(0.0), EndPointZ(0.0),
-  EngyMC(0.0), ThetaMC(0.0), PhiMC(0.0),
-  DiffTheta(0.), DiffPosXY(0.),
-  MergedV(0),
-  OutsideReason(""),
-  Hit(),
-  gmc(_gmc)
-{
+ClusterClass::ClusterClass(GlobalMethodsClass& _gmc, int idNow, int armNow, VInt const& cells, VDouble const& cellEnergies)
+    : Id(idNow),
+      Pdg(0),
+      SignMC(armNow),
+      ParentId(-1),
+      NumMCDaughters(0),
+      OutsideFlag(0),
+      MatchFlag(0),
+      HighestEnergyFlag(0),
+      ModifiedFlag(0),
+      NumHits(0),
+      Engy(0.0),
+      Theta(0.0),
+      Phi(0.0),
+      RZStart(0.0),
+      VtxX(0.0),
+      VtxY(0.0),
+      VtxZ(0.0),
+      EndPointX(0.0),
+      EndPointY(0.0),
+      EndPointZ(0.0),
+      EngyMC(0.0),
+      ThetaMC(0.0),
+      PhiMC(0.0),
+      DiffTheta(0.),
+      DiffPosXY(0.),
+      MergedV(0),
+      OutsideReason(""),
+      Hit(),
+      gmc(_gmc) {
+  int cellNow = 0;
+  for (VInt::const_iterator cellIt = cells.begin(); cellIt != cells.end(); ++cellIt, ++cellNow) {
+    FillHit(*cellIt, cellEnergies.at(cellNow));  //Adds to Engy!
+  }
+
   clusterPosition[0] = 0.0;
   clusterPosition[1] = 0.0;
   clusterPosition[2] = 0.0;
   mcpPosition[0] = 0.0;
   mcpPosition[1] = 0.0;
   mcpPosition[2] = 0.0;
-}
 
-ClusterClass::~ClusterClass() {
-
+  ResetStats();  // calculate energy, position for the cluster
 }
 
 void ClusterClass::SetStatsMC(EVENT::MCParticle * mcParticle) {

--- a/source/LumiCalReco/src/ClusterClass.cpp
+++ b/source/LumiCalReco/src/ClusterClass.cpp
@@ -170,23 +170,25 @@ int ClusterClass::ResetStats() {
   }
 
   const double logConstant(gmc.GlobalParamD[GlobalMethodsClass::LogWeightConstant]);
+  const double rMin(gmc.GlobalParamD[GlobalMethodsClass::RMin]);
+
   double       xtemp(0.0), ytemp(0.0), ztemp(0.0), thetaSum(0.0), weightSum(0.0);
   std::map<GlobalMethodsClass::Coordinate_t, double> thetaPhiCellV;
 
   for (auto const& pairIDEng : Hit) {
+    const int cellId = pairIDEng.first;
+    gmc.ThetaPhiCell(cellId, thetaPhiCellV);
+    const double phi   = thetaPhiCellV[GlobalMethodsClass::COPhi];
+    const double rcell = thetaPhiCellV[GlobalMethodsClass::COR];
+
     const double weightNow =
-        GlobalMethodsClass::posWeight(pairIDEng.second, Engy, GlobalMethodsClass::LogMethod, logConstant);
+        GlobalMethodsClass::posWeight(pairIDEng.second, Engy, GlobalMethodsClass::LogMethod, logConstant) * rMin / rcell;
 
     if (not(weightNow > 0))
       continue;
 
-    const int cellId = pairIDEng.first;
-    gmc.ThetaPhiCell(cellId, thetaPhiCellV);
-
     weightSum += weightNow;
     thetaSum  += thetaPhiCellV[GlobalMethodsClass::COTheta] * weightNow;
-    const double phi = thetaPhiCellV[GlobalMethodsClass::COPhi];
-    const double rcell = thetaPhiCellV[GlobalMethodsClass::COR];
     xtemp += rcell*cos(phi) * weightNow;
     ytemp += rcell*sin(phi) * weightNow;
     ztemp += thetaPhiCellV[GlobalMethodsClass::COZ] * weightNow;

--- a/source/LumiCalReco/src/ClusterClass.cpp
+++ b/source/LumiCalReco/src/ClusterClass.cpp
@@ -16,105 +16,13 @@ using namespace streamlog;
 /* --------------------------------------------------------------------------
    This class holds information about the clusters
    -------------------------------------------------------------------------- */
-ClusterClass::ClusterClass(GlobalMethodsClass& _gmc, int idNow, int armNow, VInt const& cells, VDouble const& cellEnergies)
-    : Id(idNow),
-      Pdg(0),
-      SignMC(armNow),
-      ParentId(-1),
-      NumMCDaughters(0),
-      OutsideFlag(0),
-      MatchFlag(0),
-      HighestEnergyFlag(0),
-      ModifiedFlag(0),
-      NumHits(0),
-      Engy(0.0),
-      Theta(0.0),
-      Phi(0.0),
-      RZStart(0.0),
-      VtxX(0.0),
-      VtxY(0.0),
-      VtxZ(0.0),
-      EndPointX(0.0),
-      EndPointY(0.0),
-      EndPointZ(0.0),
-      EngyMC(0.0),
-      ThetaMC(0.0),
-      PhiMC(0.0),
-      DiffTheta(0.),
-      DiffPosXY(0.),
-      MergedV(0),
-      OutsideReason(""),
-      Hit(),
-      gmc(_gmc) {
-  int cellNow = 0;
-  for (VInt::const_iterator cellIt = cells.begin(); cellIt != cells.end(); ++cellIt, ++cellNow) {
-    FillHit(*cellIt, cellEnergies.at(cellNow));  //Adds to Engy!
-  }
-
-  clusterPosition[0] = 0.0;
-  clusterPosition[1] = 0.0;
-  clusterPosition[2] = 0.0;
-  mcpPosition[0] = 0.0;
-  mcpPosition[1] = 0.0;
-  mcpPosition[2] = 0.0;
-
-  ResetStats();  // calculate energy, position for the cluster
+ClusterClass::ClusterClass(GlobalMethodsClass& _gmc, int idNow, LCCluster const* thisCluster)
+    : m_clusterInfo(thisCluster), Id(idNow), gmc(_gmc) {
+  ResetStats();
 }
 
-void ClusterClass::SetStatsMC(EVENT::MCParticle * mcParticle) {
-
-  Pdg = (int)mcParticle->getPDG();
-  Id  = (int)mcParticle -> id();
-  NumMCDaughters = (int)mcParticle -> getDaughters().size();
-
-  VtxX = (double)mcParticle->getVertex()[0];
-  VtxY = (double)mcParticle->getVertex()[1];
-  VtxZ = (double)mcParticle->getVertex()[2];
-
-  EndPointX = (double)mcParticle->getEndpoint()[0];
-  EndPointY = (double)mcParticle->getEndpoint()[1];
-  EndPointZ = (double)mcParticle->getEndpoint()[2];
-
-  EngyMC        = (double)mcParticle->getEnergy();
-
-  const double MCmomX = (double)mcParticle->getMomentum()[0];
-  const double MCmomY = (double)mcParticle->getMomentum()[1];
-  const double MCmomZ = (double)mcParticle->getMomentum()[2];
-
-  SignMC = int (MCmomZ / fabs(MCmomZ));
-  // unboost momentum
-  double betgam = tan( gmc.GlobalParamD[GlobalMethodsClass::BeamCrossingAngle]/2. );
-  double gama = sqrt( 1.+ betgam*betgam);
-  double localPX =-betgam*EngyMC + gama*MCmomX;
-  // position at face of Lcal
-  mcpPosition[0] = VtxX + double(SignMC)*gmc.GlobalParamD[GlobalMethodsClass::ZStart]*tan(localPX /MCmomZ);
-  mcpPosition[1] = VtxY + double(SignMC)*gmc.GlobalParamD[GlobalMethodsClass::ZStart]*tan(MCmomY/MCmomZ);
-  mcpPosition[2] = gmc.GlobalParamD[GlobalMethodsClass::ZStart]*double(SignMC);
-
-  double MCr = sqrt( localPX*localPX  + MCmomY*MCmomY);
-  ThetaMC = atan(MCr / fabs(MCmomZ));                  // Theta in local LCal coordinates
-  // (BP)get phi angle in the range (0.; +- M_PI) - default in LC  
-  PhiMC = atan2( mcpPosition[1], mcpPosition[0]);
-
-  // correction for the polar angle for cases where the particle does not
-  // come from the IP (according to a projection on the face of LumiCal)
-  if( fabs(VtxZ) > _VERY_SMALL_NUMBER ) {
-    MCr = tan(ThetaMC) * (gmc.GlobalParamD[GlobalMethodsClass::ZStart] - fabs(VtxZ));
-    ThetaMC = atan( MCr / gmc.GlobalParamD[GlobalMethodsClass::ZStart] );
-  }
-
-
-  // find the original parent of the particle
-  EVENT::MCParticle *mcParticleParent = mcParticle;
-  ParentId = Id;
-  while(1) {
-    if( !(mcParticleParent -> isCreatedInSimulation()) or mcParticleParent -> getParents().empty() )
-      break;
-
-    mcParticleParent = mcParticleParent -> getParents()[0];
-    ParentId = (int)mcParticleParent -> id();
-  }
-
+void ClusterClass::SetStatsMC(SMCInfo const& mcInfo) {
+  m_mcInfo = mcInfo;
 
   return;
 }
@@ -122,97 +30,31 @@ void ClusterClass::SetStatsMC(EVENT::MCParticle * mcParticle) {
 
 
 void ClusterClass::SetStatsMC() {
-
-  ParentId = -1;
-  Pdg = Id = SignMC = NumHits = NumMCDaughters = 0;
-  VtxX = VtxY = VtxZ = 0.;
-  EndPointX = EndPointY = EndPointZ = 0.;
-  ThetaMC = PhiMC = EngyMC = 0.;
-
-
+  Id       = 0;
+  m_mcInfo = std::make_shared<MCInfo>();
   return;
 }
-
-
-
-void ClusterClass::FillHit(int cellNow, double engyNow) {
-
-  Hit[cellNow] += engyNow;
-  Engy         += engyNow;
-
-  return;
-}
-
 
 int ClusterClass::ResetStats() {
-
-  // initialize modification flag
-  ModifiedFlag = 0;
-
-  // re-sum energy from all cells (just in case)
-  NumHits = Hit.size();
-  Engy    = 0.0;
-  for (auto const& pairIDEng : Hit) {
-    Engy += pairIDEng.second;
-  }
-
-  // if the particle has no deposits in LumiCal
-  // (BP) this already done in getCalHits method !?
-  if(Engy < _VERY_SMALL_NUMBER) {
+  // if the cluster has no deposits in LumiCal
+  if (m_clusterInfo->getEnergy() < _VERY_SMALL_NUMBER) {
     OutsideFlag = 1;
     OutsideReason = "No energy deposits at all";
     return 0;
   }
 
-  if( NumHits < gmc.GlobalParamI[GlobalMethodsClass::ClusterMinNumHits] ){
+  if (int(m_clusterInfo->getCaloHits().size()) < gmc.GlobalParamI[GlobalMethodsClass::ClusterMinNumHits]) {
     OutsideFlag = 1;
     OutsideReason = " Number of hits below minimum";
   }
 
-  const double logConstant(gmc.GlobalParamD[GlobalMethodsClass::LogWeightConstant]);
-  const double rMin(gmc.GlobalParamD[GlobalMethodsClass::RMin]);
-
-  double       xtemp(0.0), ytemp(0.0), ztemp(0.0), thetaSum(0.0), weightSum(0.0);
-  std::map<GlobalMethodsClass::Coordinate_t, double> thetaPhiCellV;
-
-  for (auto const& pairIDEng : Hit) {
-    const int cellId = pairIDEng.first;
-    gmc.ThetaPhiCell(cellId, thetaPhiCellV);
-    const double phi   = thetaPhiCellV[GlobalMethodsClass::COPhi];
-    const double rcell = thetaPhiCellV[GlobalMethodsClass::COR];
-
-    const double weightNow =
-        GlobalMethodsClass::posWeight(pairIDEng.second, Engy, GlobalMethodsClass::LogMethod, logConstant) * rMin / rcell;
-
-    if (not(weightNow > 0))
-      continue;
-
-    weightSum += weightNow;
-    thetaSum  += thetaPhiCellV[GlobalMethodsClass::COTheta] * weightNow;
-    xtemp += rcell*cos(phi) * weightNow;
-    ytemp += rcell*sin(phi) * weightNow;
-    ztemp += thetaPhiCellV[GlobalMethodsClass::COZ] * weightNow;
-  }
-
-
-  Theta  = thetaSum / weightSum;
-  xtemp /= weightSum;
-  ytemp /= weightSum;
-  ztemp /= weightSum;
-  RZStart  = atan(fabs(Theta)) * gmc.GlobalParamD[GlobalMethodsClass::ZStart];
-  Phi = atan2(ytemp, xtemp);
-
-  const double r     = sqrt(xtemp * xtemp + ytemp * ytemp + ztemp * ztemp);
-  clusterPosition[0] = r * sin(Theta) * cos(Phi);
-  clusterPosition[1] = r * sin(Theta) * sin(Phi);
-  clusterPosition[2] = r * cos(Theta);
-
-  if( Theta < gmc.GlobalParamD[GlobalMethodsClass::ThetaMin] || Theta > gmc.GlobalParamD[GlobalMethodsClass::ThetaMax] ){
+  if (m_clusterInfo->getTheta() < gmc.GlobalParamD[GlobalMethodsClass::ThetaMin] ||
+      m_clusterInfo->getTheta() > gmc.GlobalParamD[GlobalMethodsClass::ThetaMax]) {
     OutsideFlag = 1;
     OutsideReason = "Reconstructed outside the fiducial volume";
   }
 
-  if (Engy < gmc.GlobalParamD[GlobalMethodsClass::MinClusterEngyGeV]) {
+  if (m_clusterInfo->getEnergy() < gmc.GlobalParamD[GlobalMethodsClass::MinClusterEngyGeV]) {
     OutsideFlag = 1;
     OutsideReason = "Cluster energy below minimum";
   }
@@ -223,36 +65,46 @@ int ClusterClass::ResetStats() {
 
 void ClusterClass::PrintInfo(){
   // clang-format off
-  streamlog_out( MESSAGE4 ) << std::endl
-    << "ClusterClass Information:   " << Id << std::endl
-    << std::setw(30) << "sign, engyHits, engyMC, nHits:"
-    << std::setw(13) << SignMC
-    << std::setw(13) << Engy
-    << std::setw(13) << EngyMC
-    << std::setw(13) << Hit.size() << std::endl
-    << std::setw(30) << "theta mc,rec:  "
-    << std::setw(13) << ThetaMC
-    << std::setw(13) << Theta << std::endl
-    << std::setw(30) << "phi mc,rec:  "
-    << std::setw(13) << PhiMC
-    << std::setw(13) << Phi << std::endl
-    << std::setw(30) << "vertex X,Y,Z:  "
-    << std::setw(13) << VtxX
-    << std::setw(13) << VtxY
-    << std::setw(13) << VtxZ << std::endl
-    << std::setw(30) << "CLstart  X,Y,Z:  "
-    /*
-    << std::setw(13) << clusterPosition[0]
-    << std::setw(13) << clusterPosition[1]
-    << std::setw(13) << clusterPosition[2] << std::endl
-    */
-			    << std::setw(13) << RZStart*cos(Phi)
-			    << std::setw(13) << RZStart*sin(Phi)
-			    << std::setw(13) << gmc.GlobalParamD[GlobalMethodsClass::ZStart]*double(SignMC) << std::endl
-    << std::setw(30) << "MCstart  X,Y,Z:  "
-    << std::setw(13) << mcpPosition[0]
-    << std::setw(13) << mcpPosition[1]
-    << std::setw(13) << mcpPosition[2] << std::endl
+  streamlog_out(DEBUG6) << std::endl
+                        << "ClusterClass Information:   " << Id << std::endl
+                        << std::setw(30) << "sign, engyHits, engyMC, nHits:"
+                        << std::setw(13) << m_mcInfo->sign
+                        << std::setw(13) << m_clusterInfo->getEnergy()
+                        << std::setw(13) << m_mcInfo->engy
+                        << std::setw(13) << m_clusterInfo->getCaloHits().size() << std::endl
+                        << std::setw(30) << "theta mc,rec:  "
+                        << std::setw(13) << m_mcInfo->theta
+                        << std::setw(13) << m_clusterInfo->getTheta() << std::endl
+                        << std::setw(30) << "phi mc,rec:  "
+                        << std::setw(13) << m_mcInfo->phi
+                        << std::setw(13) << m_clusterInfo->getPhi() << std::endl
+                        << std::setw(30) << "vertex X,Y,Z:  "
+                        << std::setw(13) << m_mcInfo->m_vtxX
+                        << std::setw(13) << m_mcInfo->m_vtxY
+                        << std::setw(13) << m_mcInfo->m_vtxZ << std::endl
+                        << std::setw(30) << "CLstart  X,Y,Z:  "
+                        << std::setw(13) << m_clusterInfo->getPositionAtFront()[0]
+                        << std::setw(13) << m_clusterInfo->getPositionAtFront()[1]
+                        << std::setw(13) << m_clusterInfo->getPositionAtFront()[2] << std::endl
+                        << std::setw(30) << "MCstart  X,Y,Z:  "
+                        << std::setw(13) << m_mcInfo->mcPosition[0]
+                        << std::setw(13) << m_mcInfo->mcPosition[1]
+                        << std::setw(13) << m_mcInfo->mcPosition[2] << std::endl
+                        << std::endl;
+  // clang-format on
+}
+
+std::ostream& operator<<(std::ostream& o, const ClusterClass& rhs) {
+  // clang-format off
+  o << std::setw(20) << "X, Y, Z:" << std::endl << std::fixed << std::setprecision(3)
+    << std::setw(13) << rhs.getPosition()[0]
+    << std::setw(13) << rhs.getPosition()[1]
+    << std::setw(13) << rhs.getPosition()[2] << std::endl
+    << std::setw(20) << "Energy, Theta, Phi: " << std::endl
+    << std::setw(13) << rhs.getEnergy()
+    << std::setw(13) << rhs.getTheta()
+    << std::setw(13) << rhs.getPhi() << std::endl
     << std::endl;
+  return o;
   // clang-format on
 }

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -202,7 +202,8 @@ void GlobalMethodsClass::ThetaPhiCell(int cellId , std::map <GlobalMethodsClass:
   // phi
   //(BP) use phiCell size and account for possible layers relative offset/stagger
   // double phiCell   = 2 * M_PI * (double(cellIdPhi) + .5) / double(GlobalParamI[NumCellsPhi]) + double( cellIdZ % 2 ) * GlobalParamD[;
-  double phiCell   = (double(cellIdPhi) + .0) * GlobalParamD[PhiCellLength] + double( (cellIdZ) % 2 ) * GlobalParamD[ZLayerPhiOffset];
+  double phiCell = (double(cellIdPhi)) * GlobalParamD[PhiCellLength] +
+                   double((cellIdZ) % 2) * GlobalParamD[ZLayerPhiOffset] + GlobalParamD[PhiCellOffset];
   phiCell = ( phiCell > M_PI ) ? phiCell-2.*M_PI : phiCell;
   // fill output container
   thetaPhiCell[GlobalMethodsClass::COTheta] = thetaCell;
@@ -226,6 +227,7 @@ std::string GlobalMethodsClass::GetParameterName ( Parameter_t par ){
   case RCellLength:	                 return "RCellLength";
   case RCellOffset:	                 return "RCellOffset";
   case PhiCellLength:	                 return "PhiCellLength";
+  case PhiCellOffset:	                 return "PhiCellOffset";
   case ZLayerThickness:	                 return "ZLayerThickness";
   case ZLayerPhiOffset:	                 return "ZLayerPhiOffset";
   case ZLayerZOffset:	                 return "ZLayerZOffset";
@@ -294,6 +296,7 @@ void GlobalMethodsClass::SetGeometryGear() {
   GlobalParamD[RCellLength]   = _lcalGearPars.getLayerLayout().getCellSize0(0);
   GlobalParamD[RCellOffset]   = 0.0;
   GlobalParamD[PhiCellLength] = _lcalGearPars.getLayerLayout().getCellSize1(0);
+  GlobalParamD[PhiCellOffset] = 0.0;
   GlobalParamI[NumCellsR]   = (int)( (GlobalParamD[RMax]-GlobalParamD[RMin]) / GlobalParamD[RCellLength]);
   GlobalParamI[NumCellsPhi] = (int)(2.0 * M_PI / GlobalParamD[PhiCellLength] + 0.5);
   GlobalParamI[NumCellsZ] = _lcalGearPars.getLayerLayout().getNLayers();
@@ -335,6 +338,7 @@ bool GlobalMethodsClass::SetGeometryDD4HEP() {
   ParDou* rPar = dynamic_cast<ParDou*>(readout.segmentation()->parameter("grid_size_r"));
   ParDou* rOff = dynamic_cast<ParDou*>(readout.segmentation()->parameter("offset_r"));
   ParDou* pPar = dynamic_cast<ParDou*>(readout.segmentation()->parameter("grid_size_phi"));
+  ParDou* pOff = dynamic_cast<ParDou*>(readout.segmentation()->parameter("offset_phi"));
 
   if (rPar == NULL or pPar == NULL ) {
     throw std::runtime_error( "Could not obtain parameters from segmentation" );
@@ -343,6 +347,7 @@ bool GlobalMethodsClass::SetGeometryDD4HEP() {
   GlobalParamD[RCellLength]   = rPar->typedValue()/dd4hep::mm;
   GlobalParamD[RCellOffset]   = 0.5 * GlobalParamD[RCellLength] + GlobalParamD[RMin] - rOff->typedValue() / dd4hep::mm;
   GlobalParamD[PhiCellLength] = pPar->typedValue()/dd4hep::radian;
+  GlobalParamD[PhiCellOffset] = pOff->typedValue() / dd4hep::radian;
   GlobalParamI[NumCellsR]     = (int)( (GlobalParamD[RMax]-GlobalParamD[RMin]) / GlobalParamD[RCellLength]);
   GlobalParamI[NumCellsPhi]   = (int)(2.0 * M_PI / GlobalParamD[PhiCellLength] + 0.5);
   GlobalParamI[NumCellsZ]     = layers.size();

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -38,7 +38,6 @@ bool convert(std::string input, T &value) {
 }
 
 GlobalMethodsClass :: GlobalMethodsClass() :
-  _procName( "MarlinLumiCalClusterer" ),
   _useDD4hep(false),
   _backwardRotationPhi(0.0),
   GlobalParamI(),
@@ -48,44 +47,6 @@ GlobalMethodsClass :: GlobalMethodsClass() :
   _backwardCalo(NULL)
 {
 }
-GlobalMethodsClass :: GlobalMethodsClass(const std::string &name) :
-  _procName( name ),
-  _useDD4hep(false),
-  _backwardRotationPhi(0.0),
-  GlobalParamI(),
-  GlobalParamD(),
-  GlobalParamS(),
-  _forwardCalo(NULL),
-  _backwardCalo(NULL)
-{
-}
-
-
-GlobalMethodsClass::GlobalMethodsClass( const GlobalMethodsClass &rhs ):
-  _procName( rhs._procName ),
-  _useDD4hep(rhs._useDD4hep),
-  _backwardRotationPhi(rhs._backwardRotationPhi),
-  GlobalParamI( rhs.GlobalParamI ),
-  GlobalParamD( rhs.GlobalParamD ),
-  GlobalParamS( rhs.GlobalParamS ),
-  _forwardCalo( rhs._forwardCalo ),
-  _backwardCalo( rhs._backwardCalo )
-{
-}
-
-GlobalMethodsClass& GlobalMethodsClass::operator=( const GlobalMethodsClass &rhs ){
-  _procName = rhs._procName;
-  _useDD4hep = rhs._useDD4hep;
-  _backwardRotationPhi = rhs._backwardRotationPhi,
-  GlobalParamI = rhs.GlobalParamI;
-  GlobalParamD = rhs.GlobalParamD;
-  GlobalParamS = rhs.GlobalParamS;
-  _forwardCalo = rhs._forwardCalo;
-  _backwardCalo = rhs._backwardCalo;
-
-  return *this;
-}
-
 
 GlobalMethodsClass :: ~GlobalMethodsClass(){
 }
@@ -215,7 +176,10 @@ void GlobalMethodsClass::SetConstants( marlin::Processor* procPTR ) {
   GlobalParamD[BetaGamma] = beta;
   GlobalParamD[Gamma] = sqrt( 1. + beta*beta );
 
-
+  m_armCosAngle[-1] = cos(-GlobalParamD[GlobalMethodsClass::BeamCrossingAngle] / 2.);
+  m_armCosAngle[1]  = cos(GlobalParamD[GlobalMethodsClass::BeamCrossingAngle] / 2.);
+  m_armSinAngle[-1] = sin(-GlobalParamD[GlobalMethodsClass::BeamCrossingAngle] / 2.);
+  m_armSinAngle[1]  = sin(GlobalParamD[GlobalMethodsClass::BeamCrossingAngle] / 2.);
 }
 
 double GlobalMethodsClass::toSignal(double value) const { return value * getCalibrationFactor(); }

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -4,23 +4,9 @@
 #include <iostream>
 #include <iomanip>
 
-LCCluster::LCCluster()
-    : _position{0.0, 0.0, 0.0},
-      _energy(0.0),
-      _weight(0.0),
-      _method(GlobalMethodsClass::LogMethod),
-      _theta(0.0),
-      _phi(0.0),
-      _caloHits{} {}
+LCCluster::LCCluster() {}
 
-LCCluster::LCCluster(const VirtualCluster& vc)
-    : _position{vc.getX(), vc.getY(), vc.getZ()},
-      _energy(0.0),
-      _weight(0.0),
-      _method(GlobalMethodsClass::LogMethod),
-      _theta(0.0),
-      _phi(0.0),
-      _caloHits{} {}
+LCCluster::LCCluster(const VirtualCluster& vc) : _position{vc.getX(), vc.getY(), vc.getZ()} {}
 
 LCCluster::LCCluster(double energy, double x, double y, double z, double weight,
                      GlobalMethodsClass::WeightingMethod_t method, double theta, double phi, VecCalHit const& caloHitVector)
@@ -109,4 +95,10 @@ void LCCluster::recalculatePositionFromHits(GlobalMethodsClass const& gmc) {
   _position[0] = r * sin(_theta) * cos(_phi);
   _position[1] = r * sin(_theta) * sin(_phi);
   _position[2] = r * cos(_theta);
+
+  //cluster position at front-face of LumiCal
+  _rzStart            = atan(fabs(_theta)) * gmc.GlobalParamD.at(GlobalMethodsClass::ZStart);
+  _positionAtFront[0] = _rzStart * cos(_phi);
+  _positionAtFront[1] = _rzStart * sin(_phi);
+  _positionAtFront[2] = gmc.GlobalParamD.at(GlobalMethodsClass::ZStart);
 }

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -72,15 +72,19 @@ void LCCluster::recalculatePositionFromHits(GlobalMethodsClass const& gmc) {
     _energy += calHit->getEnergy();
   }
 
+  const double rMin = gmc.GlobalParamD.at(GlobalMethodsClass::RMin);
+
   double thetaTemp(0.0), weightsTemp(0.0), xTemp(0.0), yTemp(0.0), zTemp(0.0);
   for (auto const& calHit : _caloHits) {
     const auto*  pos    = calHit->getPosition();
-    const double weight = GlobalMethodsClass::posWeight(calHit->getEnergy(), _energy, _method, logConstant);
+    const double rCell  = sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
+    //cell area scales with radius, reduce weight for cells at larger radii
+    const double weight = GlobalMethodsClass::posWeight(calHit->getEnergy(), _energy, _method, logConstant) * rMin / rCell;
+
     if (not(weight > 0))
       continue;
 
-    const double r     = sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
-    const double theta = atan(r / pos[2]);
+    const double theta = atan(rCell / pos[2]);
 
     thetaTemp += theta * weight;
 

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -61,8 +61,7 @@ LumiCalClustererClass::LumiCalClustererClass(std::string const& lumiNameNow)
       _numHitsInArm(),
       _mydecoder(),
       _gmc(),
-      _useDD4hep(false),
-      RotMat() {}
+      _useDD4hep(false) {}
 
 /* ============================================================================
    initial action before first event analysis starts:
@@ -85,10 +84,6 @@ void LumiCalClustererClass::init( GlobalMethodsClass const& gmc ){
   _elementsPercentInShowerPeakLayer	= gmc.GlobalParamD.at(GlobalMethodsClass::ElementsPercentInShowerPeakLayer); // = 0.03  //APS 0.04;
   _nNearNeighbor			= gmc.GlobalParamI.at(GlobalMethodsClass::NumOfNearNeighbor); // = 6; // number of near neighbors to consider
   _beamCrossingAngle                    = gmc.GlobalParamD.at(GlobalMethodsClass::BeamCrossingAngle)/2.;
-  RotMat[-1]["cos"]                     = cos( - _beamCrossingAngle );
-  RotMat[-1]["sin"]                     = sin( - _beamCrossingAngle );
-  RotMat[ 1]["cos"]                     = cos( _beamCrossingAngle );
-  RotMat[ 1]["sin"]                     = sin( _beamCrossingAngle );
 
   // the minimal energy to take into account in the initial clustering pass is
   // defined as _middleEnergyHitBoundFrac of the minimal energy that is taken into

--- a/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
@@ -372,36 +372,6 @@ void LumiCalClustererClass::getThetaPhiZCluster( MapIntCalHit  const& calHitsCel
   return ;
 }
 
-
-/* --------------------------------------------------------------------------
-   compute the theta/phi of a cell with a given cellId
-   -------------------------------------------------------------------------- */
-double LumiCalClustererClass::thetaPhiCell(int cellId, GlobalMethodsClass::Coordinate_t output) {
-
-  int	cellIdR, cellIdZ, cellIdPhi, arm;
-  GlobalMethodsClass::CellIdZPR(cellId, cellIdZ, cellIdPhi, cellIdR, arm);
-  double	rCell, zCell, thetaCell, phiCell, outputVal(-1);
-
-  if(output == GlobalMethodsClass::COTheta) {
-    rCell      = _rMin + (cellIdR + .5) * _rCellLength;
-    zCell      = fabs(_zFirstLayer) + _zLayerThickness * (cellIdZ - 1);
-    thetaCell  = atan(rCell / zCell);
-    outputVal  = thetaCell;
-  }
-  else if(output == GlobalMethodsClass::COPhi) {
-    //(BP) account for possible layer offset
-    //    phiCell   = 2*M_PI * (double(cellIdPhi) + .5) / _cellPhiMax;
-    phiCell   = (double(cellIdPhi) + .0) * _phiCellLength + double( (cellIdZ)%2 ) * _zLayerPhiOffset;
-    phiCell = ( phiCell > M_PI ) ? phiCell - 2.*M_PI : phiCell;
-    outputVal = phiCell;
-  }
-
-  return outputVal;
-
-}
-
-
-
 /* --------------------------------------------------------------------------
    get the energy around a cluster CM within a distanceToScan raduis
    -------------------------------------------------------------------------- */

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -175,7 +175,7 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
 }
 
 LCCollection* LumiCalClustererClass::createCaloHitCollection(LCCollection* simCaloHitCollection) const {
-  streamlog_out(MESSAGE) << "Creating the CalorimeterHit collection with dummy digitization" << std::endl;
+  streamlog_out(DEBUG7) << "Creating the CalorimeterHit collection with dummy digitization" << std::endl;
 
   const double calibrationFactor = _gmc.getCalibrationFactor();
 

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -109,24 +109,6 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
       // skip this hit if the following conditions are met
       if(layer >= _maxLayerToAnalyse || layer < 0 )	continue;
 
-      
-      /*(BP) it is not safe - in case non-zero crossing angle
-            - phi sectors numbering order changes on -ve side
-            - in some models there is layers relative phi offset  
-            - also in local system zHit is +ve always
-     
-      const double rHit = (rCell+0.5) * _rCellLength + _rMin;
-      //const double phiHit = (phiCell+0.5) * _phiCellLength;
-      const double phiHit =  phiCell * _phiCellLength + double( (layer+1)%2 )*_zLayerPhiOffset;
-
-      // compute x.y.z hit coordinates ( local )
-      const float xHit = rHit * cos(phiHit);
-      const float yHit = rHit * sin(phiHit);
-      const float zHit = _zFirstLayer + float( layer ) * _zLayerThickness;
-
-      // write x,y,z to an array
-      float hitPosV[3] = {xHit, yHit, zHit};
-      */
       const float* Pos = calHitIn->getPosition();
       double       locPos[3] = {0.0, 0.0, 0.0};
       _gmc.rotateToLumiCal(Pos, locPos);

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -129,9 +129,7 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
       */
       const float* Pos = calHitIn->getPosition();
       double       locPos[3] = {0.0, 0.0, 0.0};
-      locPos[0] =  Pos[0]*RotMat[arm]["cos"] - Pos[2]*RotMat[arm]["sin"];
-      locPos[1] =  Pos[1];
-      locPos[2] =  Pos[0]*RotMat[arm]["sin"] + Pos[2]*RotMat[arm]["cos"];
+      _gmc.rotateToLumiCal(Pos, locPos);
 
 #if _GENERAL_CLUSTERER_DEBUG == 1
         streamlog_out(DEBUG2) << std::scientific << std::setprecision(3);

--- a/source/LumiCalReco/src/MCInfo.cpp
+++ b/source/LumiCalReco/src/MCInfo.cpp
@@ -5,16 +5,14 @@
 
 #include <iomanip>
 
-
-MCInfo MCInfo::getMCParticleInfo(EVENT::MCParticle *particle, GlobalMethodsClass& gmc) {
-
+SMCInfo MCInfo::getMCParticleInfo(EVENT::MCParticle* particle, GlobalMethodsClass& gmc) {
   const double LcalZstart = gmc.GlobalParamD[GlobalMethodsClass::ZStart];
   const double Rmin = gmc.GlobalParamD[GlobalMethodsClass::RMin];
   const double Rmax = gmc.GlobalParamD[GlobalMethodsClass::RMax];
   const double thmin = gmc.GlobalParamD[GlobalMethodsClass::ThetaMin];
   const double thmax = gmc.GlobalParamD[GlobalMethodsClass::ThetaMax];
 
-  MCInfo mcp;
+  auto mcp = std::make_shared<MCInfo>();
   // only primary particles wanted
   if( particle->isCreatedInSimulation() and not particle->getParents().empty() ) return mcp; //<--- is primary ?
 
@@ -51,10 +49,35 @@ MCInfo MCInfo::getMCParticleInfo(EVENT::MCParticle *particle, GlobalMethodsClass
 
   const double phi = atan2( begY, begX );
 
-  mcp = MCInfo( particle, engy, theta, phi, begX, begY, pdg, sign );
-  mcp.pp[0] = pp[0];
-  mcp.pp[1] = pp[1];
-  mcp.pp[2] = pp[2];
+  mcp        = std::make_shared<MCInfo>(particle, engy, theta, phi, begX, begY, LcalZstart, pdg, sign);
+  mcp->pp[0] = pp[0];
+  mcp->pp[1] = pp[1];
+  mcp->pp[2] = pp[2];
+
+  mcp->m_vtxX = double(particle->getVertex()[0]);
+  mcp->m_vtxY = double(particle->getVertex()[1]);
+  mcp->m_vtxZ = double(particle->getVertex()[2]);
+
+  mcp->m_endX = double(particle->getEndpoint()[0]);
+  mcp->m_endY = double(particle->getEndpoint()[1]);
+  mcp->m_endZ = double(particle->getEndpoint()[2]);
+
+  // find the original parent of the particle
+  EVENT::MCParticle* mcParticleParent = particle;
+  mcp->m_parentID                     = particle->id();
+  while (1) {
+    if (!(mcParticleParent->isCreatedInSimulation()) or mcParticleParent->getParents().empty())
+      break;
+    mcParticleParent = mcParticleParent->getParents()[0];
+    mcp->m_parentID  = (int)mcParticleParent->id();
+  }
+
+  // correction for the polar angle for cases where the particle does not
+  // come from the IP (according to a projection on the face of LumiCal)
+  if (fabs(mcp->m_vtxZ) > _VERY_SMALL_NUMBER) {
+    double MCr = tan(mcp->theta) * (gmc.GlobalParamD[GlobalMethodsClass::ZStart] - fabs(mcp->m_vtxZ));
+    mcp->theta = atan(MCr / gmc.GlobalParamD[GlobalMethodsClass::ZStart]);
+  }
 
   return mcp;
 
@@ -62,19 +85,20 @@ MCInfo MCInfo::getMCParticleInfo(EVENT::MCParticle *particle, GlobalMethodsClass
 
 
 std::ostream& operator<<(std::ostream & o, const MCInfo& rhs) {
+  // clang-format off
   o  << "MCInfo: "
      << "Energy " << std::setw(10) << rhs.engy
      << " PDG " << std::setw(5) << rhs.pdg
      << "  Local Pos(theta,phi) =  (" << std::setw(10) << rhs.theta << " , " << std::setw(10) << rhs.phi << " )"
      << "  Start (X, Y) = ( "
-     << std::setw(13) << rhs.x << ", "
-     << std::setw(13) << rhs.y
+     << std::setw(13) << rhs.mcPosition[0] << ", "
+     << std::setw(13) << rhs.mcPosition[1]
      << " ) "
      << " Global Momentum (X,Y,Z) =  ( "
      << std::setw(10) << rhs.pp[0] << " , "
      << std::setw(10) << rhs.pp[1] << " , "
      << std::setw(10) << rhs.pp[2] << " )";
+  // clang-format on
   return o;
-
 
 }

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -72,15 +72,12 @@ std::map < int , double > snbx;
 
       LCCollectionVec* LCalRPCol = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
 
-#if _CREATE_CLUSTERS_DEBUG == 1
-      streamlog_out(DEBUG2) << " Transfering reco results to LCalClusterCollection....."<<std::endl;
-#endif 
-  
-      for(int armNow = -1; armNow < 2; armNow += 2) {
+      streamlog_out(DEBUG6) << " Transfering reco results to LCalClusterCollection....." << std::endl;
 
-        streamlog_out(DEBUG2)<<" Arm  "<< std::setw(4)<< armNow
-			     << "\t Number of clusters: "<< LumiCalClusterer._superClusterIdToCellId[armNow].size()
-			     <<std::endl;
+      for (int armNow = -1; armNow < 2; armNow += 2) {
+        streamlog_out(DEBUG6) << " Arm  " << std::setw(4) << armNow
+                              << "\t Number of clusters: " << LumiCalClusterer._superClusterIdToCellId[armNow].size()
+                              << std::endl;
 
         for (auto const& pairIDCells : LumiCalClusterer._superClusterIdToCellId[armNow]) {
           const int  clusterId       = pairIDCells.first;
@@ -271,12 +268,12 @@ std::map < int , double > snbx;
       int numCounters = OutputManager.Counter.size();
 
       if(numCounters > 0)
-	streamlog_out(DEBUG) << std::endl << "Global counters:"  << std::endl;
+        streamlog_out(DEBUG1) << std::endl << "Global counters:" << std::endl;
 
       OutputManager.CounterIterator = OutputManager.Counter.begin();
       for(int hisNow = 0; hisNow < numCounters; hisNow++ , OutputManager.CounterIterator++) {
 	std::string counterName = (std::string)(*OutputManager.CounterIterator).first;
-	streamlog_out(DEBUG) << "\t" << OutputManager.Counter[counterName] << "  \t <->  " << counterName << std::endl;
+    streamlog_out(DEBUG1) << "\t" << OutputManager.Counter[counterName] << "  \t <->  " << counterName << std::endl;
       }
 #endif
 
@@ -302,9 +299,7 @@ std::map < int , double > snbx;
 
     // if an !E!9exception has been thrown (no *col for this event) than do....
     catch( DataNotAvailableException &e ){
-#ifdef _LC_DEBUG
-      streamlog_out(DEBUG) << "Event " << NumEvt << " has an exception"<< std::endl;
-#endif
+      streamlog_out(DEBUG7) << "Event " << NumEvt << " has an exception" << std::endl;
     }
 
     return;
@@ -343,14 +338,12 @@ std::map < int , double > snbx;
     }
     int numOfClustersNeg =  clusterIdToCellId.at(-1).size();
     int numOfClustersPos =  clusterIdToCellId.at(1).size();
-#if _CREATE_CLUSTERS_DEBUG == 1
     if( numOfClustersNeg || numOfClustersPos ){
       streamlog_out(DEBUG6) << "Initial Set Stats for LumiCal......."<< std::endl;
       streamlog_out(DEBUG6) << "     numOfClusters arm[-1] = "<< numOfClustersNeg << "\t arm[1] = "<< numOfClustersPos << std::endl;
     }else{
       streamlog_out(DEBUG6) << "Initial Set Stats for LumiCal: No clusters found in this event !"<< std::endl;
     }
-#endif
     if( numOfClustersNeg || numOfClustersPos ){ 
       for(int armNow = -1; armNow < 2; armNow += 2) {
 	double EngyMax =  0.;
@@ -413,11 +406,12 @@ std::map < int , double > snbx;
 
 #if _CREATE_CLUSTERS_DEBUG == 1
       if( mcParticlesVecNeg.size() || mcParticlesVecPos.size() ) {
-	streamlog_out(MESSAGE4) << "Transfering MC information into ClusterClass objects ......  "  << std::endl;
-	streamlog_out(MESSAGE4) << "MC particles arm z-: "<< mcParticlesVecNeg.size() << "\t arm z+: "<< mcParticlesVecPos.size() << std::endl;
+        streamlog_out(DEBUG5) << "Transfering MC information into ClusterClass objects ......  " << std::endl;
+        streamlog_out(DEBUG5) << "MC particles arm z-: " << mcParticlesVecNeg.size()
+                              << "\t arm z+: " << mcParticlesVecPos.size() << std::endl;
       }else{
-	streamlog_out(MESSAGE4) << "Transfering MC information into ClusterClass objects: No primary MCParticles"
-				<< " entering LumiCal found!"  << std::endl;
+        streamlog_out(DEBUG5) << "Transfering MC information into ClusterClass objects: No primary MCParticles"
+                              << " entering LumiCal found!" << std::endl;
       }
 #endif
     
@@ -447,11 +441,11 @@ std::map < int , double > snbx;
 	      // try to match MC true particle with cluster by comparing positions at Lumical entry
 	      //	  sort( mcParticlesVec.begin(), mcParticlesVec.end(), ThetaCompAsc );
 	      sort( mcParticlesVec.begin(), mcParticlesVec.end(), PositionCompAsc );
-	      streamlog_out(DEBUG2) << "Trying to match particle: " << mcParticlesVec[0].engy << std::endl;
-	      double dTheta  = fabs( _sortAgainstThisTheta - mcParticlesVec[0].theta );
-	      double dPos0    = sqrt( ( sqr(xs - mcParticlesVec[0].x) + sqr( ys - mcParticlesVec[0].y)));
-	      streamlog_out(DEBUG4) << "RZStart " << RZStart  << std::endl;
-	      streamlog_out(DEBUG4) << "  xs, ys "
+          streamlog_out(DEBUG4) << "Trying to match particle: " << mcParticlesVec[0].engy << std::endl;
+          double dTheta = fabs(_sortAgainstThisTheta - mcParticlesVec[0].theta);
+          double dPos0  = sqrt((sqr(xs - mcParticlesVec[0].x) + sqr(ys - mcParticlesVec[0].y)));
+          streamlog_out(DEBUG4) << "RZStart " << RZStart << std::endl;
+          streamlog_out(DEBUG4) << "  xs, ys "
 				    << std::setw(13) << xs
 				    << std::setw(13) << ys  << std::endl
 				    << "MCP x, y "
@@ -489,7 +483,8 @@ std::map < int , double > snbx;
 
 	    if( thisCluster -> Pdg != 0) {
 	      double Ereco = thisCluster->Engy;
-	      streamlog_out( MESSAGE4 ) << "\tParticle Out ("
+          // clang-format off
+          streamlog_out( DEBUG6 ) << "\tParticle Out ("
 		  << thisCluster -> OutsideReason << "):   " << clusterId << std::endl
 		  << "\t\t side(arm), pdg, parentId , NumMCDaughters = "
 		  << "\t" << thisCluster -> SignMC<<"("<<armNow<<")"
@@ -513,10 +508,12 @@ std::map < int , double > snbx;
 		  << "\t"<< std::setw(13)<<thisCluster -> Theta
 		  << "\t"<< std::setw(13)<<thisCluster -> Phi
 		  << std::endl << std::endl;
-	    }else{
-	      streamlog_out( MESSAGE4 ) << "Arm: "<< armNow << "\t Cluster: " << clusterId << " does not match MC particle !\n";
-	      thisCluster->PrintInfo();
-	    }
+          // clang-format on
+
+        } else {
+          streamlog_out(DEBUG6) << "Arm: " << armNow << "\t Cluster: " << clusterId << " does not match MC particle !\n";
+          thisCluster->PrintInfo();
+	}
 
 	  } // loop over clusters
 	} // loop over arms


### PR DESCRIPTION

BEGINRELEASENOTES
- LumiCalClusterer: scale weights by RMin/RCell to reduce polar angle bias
- LumiCalClusterer: fix azimuthal angle offset when taking segmentation from DD4hep (actually no longer used, all (I hope...) position calculations are now based on the position of the hits)
- LumiCalClusterer: Refactor ClusterClass, now using MCInfo and LCCluster to hold information, remove duplicated cluster position calculations

ENDRELEASENOTES