### PR TITLE
Add missing include functional for std::placeholders

### DIFF
--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <vector>
 #include <iomanip>
+#include <functional>
 
 /* >> */
 


### PR DESCRIPTION
Resolves #33 
BEGINRELEASENOTES
- Add missing `#include <functional>` for `std::placeholders`

ENDRELEASENOTES