### PR TITLE
Plot Style for DrawBeamcalFromDD4hep

### DIFF
--- a/source/MarlinProcessors/include/DrawBeamCalFromDD4hep.hh
+++ b/source/MarlinProcessors/include/DrawBeamCalFromDD4hep.hh
@@ -31,6 +31,8 @@ class DrawBeamCalFromDD4hep : public marlin::Processor {
   
   
   DrawBeamCalFromDD4hep() ;
+  DrawBeamCalFromDD4hep(const DrawBeamCalFromDD4hep&) = delete ;
+  DrawBeamCalFromDD4hep & operator = (const DrawBeamCalFromDD4hep&) = delete ;
 
   /** Called at the begin of the job before anything is read.
    * Use to initialize the processor, e.g. book histograms.
@@ -66,6 +68,7 @@ class DrawBeamCalFromDD4hep : public marlin::Processor {
   //std::string m_pdftitle;
   int m_nRun ;
   int m_nEvt ;
+  bool m_drawDensities;
 
   BeamCalGeo* m_bcg;
   dd4hep::DetElement m_BeamCal{};
@@ -74,8 +77,6 @@ class DrawBeamCalFromDD4hep : public marlin::Processor {
   TTree * m_tree;
   double m_x, m_y, m_z, m_energy;
 private://to shut the warnings up
-  DrawBeamCalFromDD4hep(const DrawBeamCalFromDD4hep&);
-  DrawBeamCalFromDD4hep& operator=(const DrawBeamCalFromDD4hep&);
 
   MapIdVal hitEnergies{};
 

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -104,9 +104,9 @@ DrawBeamCalFromDD4hep::DrawBeamCalFromDD4hep() : Processor("DrawBeamCalFromDD4he
 			   std::string("BeamCalCollection") ) ;
 
   registerProcessorParameter ("OutputFileBackground",
-         "Root OutputFile ",
-         m_nameOutputFile,
-         std::string("BeamCal.root") ) ;
+            "Root OutputFile ",
+            m_nameOutputFile,
+            std::string("BeamCal.root") ) ;
 
   registerProcessorParameter ("DrawDensities",
          "Option to draw area density of deposited energy rather than deposited energy per cell. "

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -327,7 +327,7 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
 
   TCanvas c1("rphi2", "rphi2", 800, 800);
   TH2D dummy("dummy", "dummy", 20, 0, 20, 200, 0, 200); //16 bits to get colours from pal->GetValueColor
-  TH2D g("g", "g;x [cm]; y [cm]; E_{dep} (GeV)", 200, -20, 20, 200, -20, 20); //16 bits to get colours from pal->GetValueColor
+  TH2D g("g", "g;x [cm]; y [cm]; E_{dep} [GeV]", 200, -20, 20, 200, -20, 20); //16 bits to get colours from pal->GetValueColor
   typedef dd4hep::DDSegmentation::TypedSegmentationParameter< std::vector<double> > ParVec;
   typedef dd4hep::DDSegmentation::TypedSegmentationParameter< double > ParDou;
   ParVec* rPar = static_cast<ParVec*>(m_seg.segmentation()->parameter("grid_r_values"));
@@ -369,7 +369,7 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
   unsigned idmin = 0;
   unsigned idmax = 0;
 
-  for (auto ehit : hitEnergies) {
+  for (auto const & ehit : hitEnergies) {
 
     unsigned int cellid = ehit.first;
     auto const& decoder = *m_seg.segmentation()->decoder();

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -382,7 +382,10 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
     if (m_drawDensities) area = (rO*rO-rI*rI)*pValues[rBin]/2 ;
     double edensity = ehit.second / area;
 
-    if (edensity < emin && rBin == rValues.size()-2) {
+    // Comparison rBin == rValues.size()-2 ensures that the lower boundary of the
+    // automatic z-axis range is calculated from the outermost BeamCal ring, rather than
+    // from the phantom cells in the keyhole.
+    if (edensity < emin && rBin == static_cast<long>(rValues.size())-2) {
       emin = edensity;
       idmin = cellid;
     }

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -374,7 +374,7 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
     double area = (rO*rO-rI*rI)*pValues[rBin]/2 ;
     double edensity = ehit.second / area;
 
-    if (edensity < emin) {
+    if (edensity < emin && rBin == rValues.size()-2) {
       emin = edensity;
       idmin = cellid;
     }
@@ -386,8 +386,8 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
     hitEDensities[cellid] = edensity;
   }
 
-  double eHi = TMath::Power(emax, 0.98)*TMath::Power(emin, 0.02);
-  double eLo = TMath::Power(emax, 0.1)*TMath::Power(emin, 0.9);
+  double eHi = emax; // TMath::Power(emax, 0.98)*TMath::Power(emin, 0.02);
+  double eLo = emin; // TMath::Power(emax, 0.1)*TMath::Power(emin, 0.9);
 
   TCrown *tcmin = NULL;
   TCrown *tcmax = NULL;

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -53,8 +53,7 @@ DrawBeamCalFromDD4hep aDrawBeamCalFromDD4hep;
 // #pragma GCC diagnostic ignored "-Wshadow"
 
 
-int getColor(double energy) {
-	Double_t minenergy=1e-3, maxenergy=1e2;
+int getColor(double energy, double minenergy=1e-3, double maxenergy=1e2) {
 	Int_t color1, color2, color;
 	double wlmin = TMath::Log10(minenergy);
 	double wlmax = TMath::Log10(maxenergy);
@@ -321,7 +320,7 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
 
   TCanvas c1("rphi2", "rphi2", 800, 800);
   TH2D dummy("dummy", "dummy", 20, 0, 20, 200, 0, 200); //16 bits to get colours from pal->GetValueColor
-  TH2D g("g", "g;x [cm]; y [cm]", 200, -20, 20, 200, -20, 20); //16 bits to get colours from pal->GetValueColor
+  TH2D g("g", "g;x [cm]; y [cm]; E_{dep} (GeV)", 200, -20, 20, 200, -20, 20); //16 bits to get colours from pal->GetValueColor
   typedef dd4hep::DDSegmentation::TypedSegmentationParameter< std::vector<double> > ParVec;
   typedef dd4hep::DDSegmentation::TypedSegmentationParameter< double > ParDou;
   ParVec* rPar = static_cast<ParVec*>(m_seg.segmentation()->parameter("grid_r_values"));
@@ -355,7 +354,14 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
 
   TCanvas c2("Segmentation", "Segmentation", 800, 800);
   c2.cd();
-  g.Draw("AXIS");
+  g.Draw("AXIS colz");
+
+  double emin=1.e4;
+  double emax=0;
+  for (auto ehit : hitEnergies) {
+    if (ehit.second < emin) emin = ehit.second;
+    if (ehit.second > emax) emax = ehit.second;
+  }
 
   for (MapIdVal::iterator it = hitEnergies.begin(); it != hitEnergies.end(); ++it) {
     unsigned int cellid = it->first;
@@ -383,10 +389,10 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
       << std::setw(14) << pO*TMath::RadToDeg()
       << std::setw(14) << energy
       << std::endl;
-    tc->SetLineColor( getColor(energy) );
+    tc->SetLineColor( getColor(energy, emin, emax) );
     tc->SetLineWidth(0);
     //    tc->SetFillColor( pal->GetValueColor(energy) );
-    tc->SetFillColor( getColor(energy) );
+    tc->SetFillColor( getColor(energy, emin, emax) );
 
     tc->Draw();
   }

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -389,10 +389,11 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
       << std::setw(14) << pO*TMath::RadToDeg()
       << std::setw(14) << energy
       << std::endl;
-    tc->SetLineColor( getColor(energy, emin, emax) );
+    double area = (rO*rO-rI*rI)*abs(pO-pI)/2;
+    tc->SetLineColor( getColor(energy/area, emin, emax) );
     tc->SetLineWidth(0);
     //    tc->SetFillColor( pal->GetValueColor(energy) );
-    tc->SetFillColor( getColor(energy, emin, emax) );
+    tc->SetFillColor( getColor(energy/area, emin, emax) );
 
     tc->Draw();
   }

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -403,7 +403,7 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
     const double pI = pValues[rBin]*pBin    +offset;
     const double pO = pValues[rBin]*(pBin+1)+offset;
   
-    if (rBin == 3 && pBin > 47) continue;
+    //if (rBin == 3 && pBin > 47) continue;
 
     TCrown *tc = new TCrown(0,0, rI, rO, pI*TMath::RadToDeg(), pO*TMath::RadToDeg());
     streamlog_out(DEBUG)

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -104,9 +104,9 @@ DrawBeamCalFromDD4hep::DrawBeamCalFromDD4hep() : Processor("DrawBeamCalFromDD4he
 			   std::string("BeamCalCollection") ) ;
 
   registerProcessorParameter ("OutputFileBackground",
-            "Root OutputFile ",
-            m_nameOutputFile,
-            std::string("BeamCal.root") ) ;
+			      "Root OutputFile ",
+			      m_nameOutputFile,
+			      std::string("BeamCal.root") ) ;
 
   registerProcessorParameter ("DrawDensities",
          "Option to draw area density of deposited energy rather than deposited energy per cell. "

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -314,6 +314,11 @@ void DrawBeamCalFromDD4hep::drawCartesianGridXY() {
 
 void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
 
+  gStyle->SetOptStat(0);
+  gStyle->SetOptTitle(0);
+  gStyle->SetTitleSize(0.05, "xyz");
+  gStyle->SetLabelSize(0.05, "xyz");
+
   TCanvas c1("rphi2", "rphi2", 800, 800);
   TH2D dummy("dummy", "dummy", 20, 0, 20, 200, 0, 200); //16 bits to get colours from pal->GetValueColor
   TH2D g("g", "g;x [cm]; y [cm]", 200, -20, 20, 200, -20, 20); //16 bits to get colours from pal->GetValueColor

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -386,9 +386,6 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
     hitEDensities[cellid] = edensity;
   }
 
-  double eHi = emax; // TMath::Power(emax, 0.98)*TMath::Power(emin, 0.02);
-  double eLo = emin; // TMath::Power(emax, 0.1)*TMath::Power(emin, 0.9);
-
   TCrown *tcmin = NULL;
   TCrown *tcmax = NULL;
 
@@ -418,10 +415,10 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
       << std::setw(14) << pO*TMath::RadToDeg()
       << std::setw(14) << edensity
       << std::endl;
-    tc->SetLineColor( getColor(edensity, eLo, eHi) );
+    tc->SetLineColor( getColor(edensity, emin, emax) );
     tc->SetLineWidth(0);
     //    tc->SetFillColor( pal->GetValueColor(energy) );
-    tc->SetFillColor( getColor(edensity, eLo, eHi) );
+    tc->SetFillColor( getColor(edensity, emin, emax) );
 
     if (cellid == idmin) tcmin = tc;
     if (cellid == idmax) tcmax = tc;
@@ -435,8 +432,8 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
   leg->SetFillStyle(0);
   leg->SetTextSize(0.04);
   leg->SetTextFont(42);
-  leg->AddEntry(tcmax, Form("E_{dep}/A > %.2g GeV/cm^{2}", eHi / (dd4hep::GeV / dd4hep::cm2) ), "f");
-  leg->AddEntry(tcmin, Form("E_{dep}/A < %.2g GeV/cm^{2}", eLo / (dd4hep::GeV / dd4hep::cm2) ), "f");
+  leg->AddEntry(tcmax, Form("E_{dep}/A > %.2g GeV/cm^{2}", emax / (dd4hep::GeV / dd4hep::cm2) ), "f");
+  leg->AddEntry(tcmin, Form("E_{dep}/A < %.2g GeV/cm^{2}", emin / (dd4hep::GeV / dd4hep::cm2) ), "f");
   leg->Draw();
 
   c2.SaveAs("Segmentation.eps");


### PR DESCRIPTION

BEGINRELEASENOTES
- Optional feature was added to DrawBeamCalFromDD4hep to draw hit energy density per unit area rather than hit energy. This option is steerable via the new parameter `DrawDensities`
- The z-axis range is calculated automatically in the polar segmentation plot of DrawBeamCalFromDD4hep.
- A simple legend is drawn in the polar segmentation plot of DrawBeamCalFromDD4hep to indicate the dynamic range of the z-axis.
- Minor style changes were made to the polar segmentation plot of DrawBeamCalFromDD4hep.
ENDRELEASENOTES