### PR TITLE
add missing header cmath to TestUtilities.hh

### DIFF
--- a/source/Tests/include/TestUtilities.hh
+++ b/source/Tests/include/TestUtilities.hh
@@ -15,6 +15,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <cmath>
 
 
 using HitMap = std::map<long long, IMPL::CalorimeterHitImpl*>;


### PR DESCRIPTION
BEGINRELEASENOTES
- add missing header cmath to TestUtilities.hh for gcc49 and gcc54

ENDRELEASENOTES