### PR TITLE
Cleanup header files with "Include what you use"

### DIFF
--- a/source/BeamCalReco/include/BCPCuts.hh
+++ b/source/BeamCalReco/include/BCPCuts.hh
@@ -3,8 +3,7 @@
 
 #include <vector>
 
-#include "BeamCalCluster.hh"
-
+class BeamCalCluster;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 // Just a container class for the cuts used in the BCPadEnergies clustering algorithms //

--- a/source/BeamCalReco/include/BCPadEnergies.hh
+++ b/source/BeamCalReco/include/BCPadEnergies.hh
@@ -2,7 +2,6 @@
 #define BCPADENERGIES_HH
 
 #include <map>
-#include <stdexcept>
 #include <vector>
 
 class BeamCalGeo;

--- a/source/BeamCalReco/include/BCPadEnergies.hh
+++ b/source/BeamCalReco/include/BCPadEnergies.hh
@@ -2,11 +2,16 @@
 #define BCPADENERGIES_HH
 
 #include <map>
+#include <string>
 #include <vector>
 
 class BeamCalGeo;
-class BeamCalCluster;
+class BeamCalCluster;  // IWYU pragma: keep
 class BCPCuts;  
+
+//needed to avoid circular includes
+// IWYU pragma: no_include "BeamCalCluster.hh"
+
 
 class BCPadEnergies{
 

--- a/source/BeamCalReco/include/BCRootUtilities.hh
+++ b/source/BeamCalReco/include/BCRootUtilities.hh
@@ -1,10 +1,7 @@
 #ifndef BCRootUtilities_hh
 #define BCRootUtilities_hh 1
 
-#include "BCPadEnergies.hh"
-
-class TFile;
-class BeamCalGeo;
+class BCPadEnergies;
 
 #include <TError.h>
 

--- a/source/BeamCalReco/include/BCUtilities.hh
+++ b/source/BeamCalReco/include/BCUtilities.hh
@@ -1,14 +1,10 @@
 #ifndef BCutilities_hh
 #define BCutilities_hh 1
 
-#include <gear/GEAR.h>
-#include <gear/GearParameters.h>
-#include <gear/LayerLayout.h>
-#include <gear/CalorimeterParameters.h>
+#include <Exceptions.h>
 
-#include <EVENT/CalorimeterHit.h>
-#include <EVENT/SimCalorimeterHit.h>
-#include <UTIL/CellIDDecoder.h>
+#include <cmath>
+#include <iostream>
 
 namespace BCUtil{
 
@@ -85,7 +81,7 @@ namespace BCUtil{
         cylinder = mydecoder( hit )["r"] ;
         sector   = mydecoder( hit )["phi"] ;
         layer    = mydecoder( hit )["layer"] - startingLayer; // starting at 1 for BeamCal at 0 for LumiCal
-      } catch (lcio::Exception &e) {
+      } catch (EVENT::Exception &e) {
         std::cout << "Exception in BCUtil with DD4hep:" << e.what()  << std::endl;
       }
     } else {
@@ -94,7 +90,7 @@ namespace BCUtil{
         cylinder = mydecoder( hit )["I"] ;
         sector   = mydecoder( hit )["J"] ;
         layer    = mydecoder( hit )["K"] ;
-      } catch (lcio::Exception &e) {
+      } catch (EVENT::Exception &e) {
         std::cout << "Exception in BCUtil without DD4hep:" << e.what()  << std::endl;
       }
 

--- a/source/BeamCalReco/include/BeamCal.hh
+++ b/source/BeamCalReco/include/BeamCal.hh
@@ -1,31 +1,23 @@
 #ifndef BEAMCAL_HH
 #define BEAMCAL_HH 1
 
-#include <TROOT.h>
-#include <TH3D.h>
-#include <TMath.h>
+#include <RtypesCore.h>
 #include <TCanvas.h>
+#include <TH3.h>
+#include <TObject.h>
+#include <TPad.h>
+#include <TString.h>
+
+#include <map>
 
 class TCrown;
 class TH1D;
 class TH2F;
 class TH2D;
-class TPad;
 
 
 class BCPadEnergies;
 class BeamCalGeo;
-
-#include <EVENT/SimCalorimeterHit.h>
-
-#include <gear/GEAR.h>
-#include <gear/GearParameters.h>
-#include <gear/LayerLayout.h>
-#include <gear/CalorimeterParameters.h>
-#include <gear/GearMgr.h>
-
-#include <vector>
-#include <map>
 
 
 class BeamCal {

--- a/source/BeamCalReco/include/BeamCalBkg.hh
+++ b/source/BeamCalReco/include/BeamCalBkg.hh
@@ -14,7 +14,6 @@
 #include "BCPadEnergies.hh"
 
 class TRandom3;
-class TTree;
 
 class BeamCalGeo;
 class BCPCuts;

--- a/source/BeamCalReco/include/BeamCalBkgAverage.hh
+++ b/source/BeamCalReco/include/BeamCalBkgAverage.hh
@@ -13,13 +13,9 @@
 #include <vector>
 
 #include "BeamCalBkg.hh"
-#include "BCPadEnergies.hh"
-
-class TFile;
-class TRandom3;
-class TTree;
 
 class BeamCalGeo;
+class BCPadEnergies;
 
 using std::vector;
 using std::string;

--- a/source/BeamCalReco/include/BeamCalBkgEmpty.hh
+++ b/source/BeamCalReco/include/BeamCalBkgEmpty.hh
@@ -7,12 +7,12 @@
 #pragma once
 
 #include "BeamCalBkg.hh"
-#include "BCPadEnergies.hh"
 
 #include <string>
 #include <vector>
 
 class BeamCalGeo;
+class BCPadEnergies;
 
 class BeamCalBkgEmpty : public BeamCalBkg {
  public:

--- a/source/BeamCalReco/include/BeamCalBkgGauss.hh
+++ b/source/BeamCalReco/include/BeamCalBkgGauss.hh
@@ -14,8 +14,6 @@
 #include "BeamCalBkg.hh"
 #include "BCPadEnergies.hh"
 
-class TFile;
-class TRandom3;
 class TTree;
 
 class BeamCalGeo;

--- a/source/BeamCalReco/include/BeamCalBkgPregen.hh
+++ b/source/BeamCalReco/include/BeamCalBkgPregen.hh
@@ -12,12 +12,10 @@
 #include <vector>
 
 #include "BeamCalBkg.hh"
-#include "BCPadEnergies.hh"
 
 class TChain;
-class TRandom3;
-class TTree;
 
+class BCPadEnergies;
 class BeamCalGeo;
 
 using std::vector;

--- a/source/BeamCalReco/include/BeamCalFitShower.hh
+++ b/source/BeamCalReco/include/BeamCalFitShower.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <vector>
-#include <utility>
 #include "BCPadEnergies.hh"
 
 class BeamCalGeo;

--- a/source/BeamCalReco/include/BeamCalFitShower.hh
+++ b/source/BeamCalReco/include/BeamCalFitShower.hh
@@ -8,8 +8,10 @@
 
 #pragma once
 
-#include <vector>
 #include "BCPadEnergies.hh"
+
+#include <vector>
+#include <map>
 
 class BeamCalGeo;
 class BeamCalBkg;

--- a/source/BeamCalReco/include/BeamCalGeo.hh
+++ b/source/BeamCalReco/include/BeamCalGeo.hh
@@ -1,8 +1,8 @@
 #ifndef BeamCalGeo_hh
 #define BeamCalGeo_hh 1
 
-#include <stdexcept>
 #include <vector>
+#include <ostream>
 
 
 /// ABC for BeamCalGeometry information

--- a/source/BeamCalReco/include/BeamCalGeoCached.hh
+++ b/source/BeamCalReco/include/BeamCalGeoCached.hh
@@ -3,6 +3,8 @@
 
 #include "BeamCalGeo.hh"
 
+#include <vector>
+
 namespace gear{
   class CalorimeterParameters;
   class GearMgr;

--- a/source/BeamCalReco/include/BeamCalGeoDD.hh
+++ b/source/BeamCalReco/include/BeamCalGeoDD.hh
@@ -3,7 +3,16 @@
 
 #include "BeamCalGeo.hh"
 
-#include <DD4hep/Detector.h>
+#include <DD4hep/DetElement.h>
+#include <DD4hep/Segmentations.h>
+
+#include <string>
+#include <vector>
+
+
+namespace dd4hep {
+  class Detector;
+}
 
 class BeamCalGeoDD : public BeamCalGeo {     
 

--- a/source/BeamCalReco/include/BeamCalGeoGear.hh
+++ b/source/BeamCalReco/include/BeamCalGeoGear.hh
@@ -8,6 +8,8 @@ namespace gear{
   class GearMgr;
 }
 
+#include <vector>
+
 class BeamCalGeoGear : public BeamCalGeo {     
 
 public:

--- a/source/BeamCalReco/src/BCPCuts.cpp
+++ b/source/BeamCalReco/src/BCPCuts.cpp
@@ -1,4 +1,5 @@
 #include "BCPCuts.hh"
+#include "BeamCalCluster.hh"
 
 bool BCPCuts::isPadAboveThreshold(int padRing, double padEnergy) const {
   for (int i = int(m_startingRings.size())-1; i >= 0; --i) {

--- a/source/BeamCalReco/src/BCPadEnergies.cpp
+++ b/source/BeamCalReco/src/BCPadEnergies.cpp
@@ -7,14 +7,10 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
+#include <memory>
+#include <sstream>  // IWYU pragma: keep
 #include <stdexcept>
-
-//typedef std::map<int, int> PadIndexList;
-// typedef BCPadEnergies::PadIndexList;
-// typedef BCPadEnergies::TowerIndexList;
-
-
+#include <utility>
 
 bool value_comparer( const BCPadEnergies::TowerIndexList::value_type &i1, const BCPadEnergies::TowerIndexList::value_type &i2)
 {

--- a/source/BeamCalReco/src/BCPadEnergies.cpp
+++ b/source/BeamCalReco/src/BCPadEnergies.cpp
@@ -4,13 +4,11 @@
 #include "BeamCalGeo.hh"
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
-
 
 //typedef std::map<int, int> PadIndexList;
 // typedef BCPadEnergies::PadIndexList;

--- a/source/BeamCalReco/src/BCRootUtilities.cpp
+++ b/source/BeamCalReco/src/BCRootUtilities.cpp
@@ -1,13 +1,12 @@
 #include "BCRootUtilities.hh"
+#include "BCPadEnergies.hh"
 #include "BeamCalGeo.hh"
-
 
 #include <TFile.h>
 #include <TTree.h>
 
 #include <iomanip>
 #include <iostream>
-#include <cmath>
 #include <stdexcept>
 #include <cstdlib>
 

--- a/source/BeamCalReco/src/BCRootUtilities.cpp
+++ b/source/BeamCalReco/src/BCRootUtilities.cpp
@@ -3,12 +3,15 @@
 #include "BeamCalGeo.hh"
 
 #include <TFile.h>
+#include <TString.h>
 #include <TTree.h>
 
+#include <cstdlib>
+#include <exception>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
-#include <cstdlib>
 
 
 void BCUtil::ReadRootFile(std::string const& fileName, std::vector<BCPadEnergies>& newPads) {

--- a/source/BeamCalReco/src/BeamCal.cpp
+++ b/source/BeamCalReco/src/BeamCal.cpp
@@ -5,8 +5,14 @@
 
 #include "BeamCalGeo.hh"
 
+#include <Rtypes.h>
+#include <TAttLine.h>
+#include <TAttMarker.h>
+#include <TAxis.h>
 #include <TCanvas.h>
 #include <TCrown.h>
+#include <TGaxis.h>
+#include <TH1.h>
 #include <TH2.h>
 #include <TH3.h>
 #include <TList.h>
@@ -14,11 +20,18 @@
 #include <TPad.h>
 #include <TPaletteAxis.h>
 #include <TStyle.h>
+#include <TVirtualPad.h>
 
+#include <string.h>
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 
 BeamCal::BeamCal(BeamCalGeo const& geo):
   m_BCG(geo),

--- a/source/BeamCalReco/src/BeamCal.cpp
+++ b/source/BeamCalReco/src/BeamCal.cpp
@@ -5,21 +5,14 @@
 
 #include "BeamCalGeo.hh"
 
-#include <gear/GEAR.h>
-#include <gear/GearMgr.h>
-#include <gear/GearParameters.h>
-#include <gear/LayerLayout.h>
-#include <gear/CalorimeterParameters.h>
-
 #include <TCanvas.h>
 #include <TCrown.h>
-#include <TH2D.h>
-#include <TH3D.h>
+#include <TH2.h>
+#include <TH3.h>
 #include <TList.h>
 #include <TMath.h>
 #include <TPad.h>
 #include <TPaletteAxis.h>
-#include <TPave.h>
 #include <TStyle.h>
 
 #include <algorithm>

--- a/source/BeamCalReco/src/BeamCalBkg.cpp
+++ b/source/BeamCalReco/src/BeamCalBkg.cpp
@@ -22,6 +22,7 @@
 // ROOT
 #include <TRandom3.h>
 
+#include <cmath>
 #include <iostream>
 #include <map>
 
@@ -29,22 +30,20 @@ using std::vector;
 using std::string;
 using std::map;
 
-BeamCalBkg::BeamCalBkg(const string& bg_method_name, 
-                     const BeamCalGeo *BCG) : 
-                                           m_bgMethod(kPregenerated),
-					   m_nBX(0),
-                                           m_BeamCalDepositsLeft(NULL),
-                                           m_BeamCalDepositsRight(NULL),
-                                           m_BeamCalAverageLeft(NULL),
-                                           m_BeamCalAverageRight(NULL),
-                                           m_BeamCalErrorsLeft(NULL),
-                                           m_BeamCalErrorsRight(NULL),
-					   m_TowerErrorsLeft(NULL),
-					   m_TowerErrorsRight(NULL),
-                                           m_random3(NULL),
-                                           m_BCG(BCG),
-                                           m_bcpCuts(NULL)
-{
+BeamCalBkg::BeamCalBkg(const string& bg_method_name, const BeamCalGeo* BCG)
+    : m_bgMethod(kPregenerated),
+      m_nBX(0),
+      m_BeamCalDepositsLeft(nullptr),
+      m_BeamCalDepositsRight(nullptr),
+      m_BeamCalAverageLeft(nullptr),
+      m_BeamCalAverageRight(nullptr),
+      m_BeamCalErrorsLeft(nullptr),
+      m_BeamCalErrorsRight(nullptr),
+      m_TowerErrorsLeft(nullptr),
+      m_TowerErrorsRight(nullptr),
+      m_random3(nullptr),
+      m_BCG(BCG),
+      m_bcpCuts(nullptr) {
   streamlog_out(MESSAGE) << "Initialising BeamCal background with \""
 			 << bg_method_name << "\" method" << std::endl;
 }

--- a/source/BeamCalReco/src/BeamCalBkg.cpp
+++ b/source/BeamCalReco/src/BeamCalBkg.cpp
@@ -11,38 +11,23 @@
 *
 */
 #include "BeamCalBkg.hh"
-#include "BeamCalGeoCached.hh"
-#include "BCPadEnergies.hh"
 #include "BCPCuts.hh"
-#include "BCRootUtilities.hh"
-
+#include "BCPadEnergies.hh"
+#include "BeamCalGeo.hh"
 
 // ----- include for verbosity dependent logging ---------
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <marlin/ProcessorEventSeeder.h>
-#include <marlin/Global.h>
-
 // ROOT
-#include <TChain.h>
-#include <TMatrixD.h>
-#include <TTree.h>
-#include <TFile.h>
-#include <TF1.h>
 #include <TRandom3.h>
 
-#include <algorithm>
-#include <iomanip>
 #include <iostream>
 #include <map>
-#include <set>
 
 using std::vector;
 using std::string;
 using std::map;
-
-using marlin::Global;
 
 BeamCalBkg::BeamCalBkg(const string& bg_method_name, 
                      const BeamCalGeo *BCG) : 

--- a/source/BeamCalReco/src/BeamCalBkgAverage.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgAverage.cpp
@@ -10,37 +10,17 @@
 *
 */
 #include "BeamCalBkgAverage.hh"
-#include "BeamCalGeoCached.hh"
 #include "BCPadEnergies.hh"
 #include "BCRootUtilities.hh"
+#include "BeamCalGeo.hh"
 
-
-// ----- include for verbosity dependent logging ---------
-#include <streamlog/loglevels.h>
-#include <streamlog/streamlog.h>
-
-#include <marlin/ProcessorEventSeeder.h>
-#include <marlin/Global.h>
-
-// ROOT
-#include <TChain.h>
-#include <TMatrixD.h>
-#include <TTree.h>
-#include <TFile.h>
-#include <TF1.h>
 #include <TRandom3.h>
 
-#include <algorithm>
-#include <iomanip>
-#include <iostream>
-#include <map>
-#include <set>
+#include <cmath>
 
 using std::vector;
 using std::string;
-using std::map;
 
-using marlin::Global;
 
 BeamCalBkgAverage::BeamCalBkgAverage(const string& bg_method_name, 
                      const BeamCalGeo *BCG) : BeamCalBkg(bg_method_name, BCG)

--- a/source/BeamCalReco/src/BeamCalBkgFactory.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgFactory.cpp
@@ -4,12 +4,13 @@
 #include "BeamCalBkgGauss.hh"
 #include "BeamCalBkgParam.hh"
 #include "BeamCalBkgPregen.hh"
-#include "BeamCalGeo.hh"
 
 #include <streamlog/streamlog.h>
 
 #include <iostream>
 #include <string>
+
+class BeamCalGeo;
 
 BeamCalBkg* BeamCalBkg::Factory(std::string const& backgroundMethod, BeamCalGeo const* BCG) {
   if (std::string("Pregenerated") == backgroundMethod) {

--- a/source/BeamCalReco/src/BeamCalBkgFactory.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgFactory.cpp
@@ -5,9 +5,11 @@
 #include "BeamCalBkgParam.hh"
 #include "BeamCalBkgPregen.hh"
 
+#include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 class BeamCalGeo;

--- a/source/BeamCalReco/src/BeamCalBkgGauss.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgGauss.cpp
@@ -6,39 +6,27 @@
 * @date 2015-06-12
 */
 
-
-#include "BeamCalBkg.hh"
 #include "BeamCalBkgGauss.hh"
-#include "BeamCalGeoCached.hh"
 #include "BCPadEnergies.hh"
-#include "BCRootUtilities.hh"
-
+#include "BeamCalBkg.hh"
+#include "BeamCalGeo.hh"
 
 // ----- include for verbosity dependent logging ---------
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <marlin/ProcessorEventSeeder.h>
-#include <marlin/Global.h>
-
 // ROOT
-#include <TMatrixD.h>
 #include <TTree.h>
 #include <TFile.h>
-#include <TF1.h>
 #include <TRandom3.h>
 
-#include <algorithm>
-#include <iomanip>
 #include <iostream>
 #include <map>
-#include <set>
 
 using std::vector;
 using std::string;
 using std::map;
 
-using marlin::Global;
 
 BeamCalBkgGauss::BeamCalBkgGauss(const string& bg_method_name, 
                      const BeamCalGeo *BCG) : BeamCalBkg(bg_method_name, BCG),

--- a/source/BeamCalReco/src/BeamCalBkgGauss.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgGauss.cpp
@@ -16,23 +16,29 @@
 #include <streamlog/streamlog.h>
 
 // ROOT
-#include <TTree.h>
+#include <TBranch.h>
 #include <TFile.h>
+#include <TObjArray.h>
+#include <TObject.h>
 #include <TRandom3.h>
+#include <TString.h>
+#include <TTree.h>
 
+#include <cmath>
 #include <iostream>
 #include <map>
+#include <memory>
+#include <stdexcept>
+#include <utility>
 
 using std::vector;
 using std::string;
 using std::map;
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 
-BeamCalBkgGauss::BeamCalBkgGauss(const string& bg_method_name, 
-                     const BeamCalGeo *BCG) : BeamCalBkg(bg_method_name, BCG),
-					   m_padParLeft(NULL),
-					   m_padParRight(NULL)
-{}
+BeamCalBkgGauss::BeamCalBkgGauss(const string& bg_method_name, const BeamCalGeo* BCG)
+    : BeamCalBkg(bg_method_name, BCG), m_padParLeft(nullptr), m_padParRight(nullptr) {}
 
 BeamCalBkgGauss::~BeamCalBkgGauss() {
   delete m_padParLeft;
@@ -136,8 +142,8 @@ void BeamCalBkgGauss::readBackgroundPars(TTree *bg_par_tree, const BCPadEnergies
   typedef map<string, vector<double> *> MapStrVec_t;
   MapStrVec_t br_cont_map;
 
-  br_cont_map[side_name+"mean"]      = NULL;
-  br_cont_map[side_name+"stdev"]     = NULL;
+  br_cont_map[side_name + "mean"]  = nullptr;
+  br_cont_map[side_name + "stdev"] = nullptr;
 
   // check the branch presence in the tree
   MapStrVec_t::iterator im = br_cont_map.begin();

--- a/source/BeamCalReco/src/BeamCalBkgParam.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgParam.cpp
@@ -13,34 +13,44 @@
 #include "BeamCalGeo.hh"
 
 // ----- include for verbosity dependent logging ---------
+#include <streamlog/baselevels.h>
 #include <streamlog/loglevels.h>
+#include <streamlog/logstream.h>
 #include <streamlog/streamlog.h>
 
 
 // ROOT
-#include <TTree.h>
-#include <TFile.h>
-#include <TF1.h>
-#include <TRandom3.h>
-#include <TMath.h>
 #include <RVersion.h>
+#include <TBranch.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TMath.h>
+#include <TObjArray.h>
+#include <TObject.h>
+#include <TRandom3.h>
+#include <TString.h>
+#include <TTree.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <map>
+#include <memory>
+#include <stdexcept>
+#include <utility>
 
 using std::vector;
 using std::string;
 using std::map;
 
+// IWYU pragma: no_include <ext/alloc_traits.h>
 
-BeamCalBkgParam::BeamCalBkgParam(const string& bg_method_name, 
-                     const BeamCalGeo *BCG) : BeamCalBkg(bg_method_name, BCG),
-					   m_padParLeft(NULL),
-					   m_padParRight(NULL),
-					   m_unuransLeft(vector<TF1*>()),
-					   m_unuransRight(vector<TF1*>())
-{}
+BeamCalBkgParam::BeamCalBkgParam(const string& bg_method_name, const BeamCalGeo* BCG)
+    : BeamCalBkg(bg_method_name, BCG),
+      m_padParLeft(nullptr),
+      m_padParRight(nullptr),
+      m_unuransLeft(vector<TF1*>()),
+      m_unuransRight(vector<TF1*>()) {}
 
 BeamCalBkgParam::~BeamCalBkgParam()
 {
@@ -178,17 +188,17 @@ void BeamCalBkgParam::readBackgroundPars(TTree *bg_par_tree, const BCPadEnergies
   // map the branch names to containers
   typedef map<string, vector<double> *> MapStrVec_t;
   MapStrVec_t br_cont_map;
-  //Set to NULL so root deals with the memory itself
-  br_cont_map[side_name+"zero_rate"] = NULL;
-  br_cont_map[side_name+"mean"]      = NULL;
-  br_cont_map[side_name+"stdev"]     = NULL;
-  br_cont_map[side_name+"sum"]       = NULL;
-  br_cont_map[side_name+"minm"]      = NULL;
-  br_cont_map[side_name+"maxm"]      = NULL;
-  br_cont_map[side_name+"chi2"]      = NULL;
-  br_cont_map[side_name+"par0"]      = NULL;
-  br_cont_map[side_name+"par1"]      = NULL;
-  br_cont_map[side_name+"par2"]      = NULL;
+  //Set to nullptr so root deals with the memory itself
+  br_cont_map[side_name + "zero_rate"] = nullptr;
+  br_cont_map[side_name + "mean"]      = nullptr;
+  br_cont_map[side_name + "stdev"]     = nullptr;
+  br_cont_map[side_name + "sum"]       = nullptr;
+  br_cont_map[side_name + "minm"]      = nullptr;
+  br_cont_map[side_name + "maxm"]      = nullptr;
+  br_cont_map[side_name + "chi2"]      = nullptr;
+  br_cont_map[side_name + "par0"]      = nullptr;
+  br_cont_map[side_name + "par1"]      = nullptr;
+  br_cont_map[side_name + "par2"]      = nullptr;
 
   // check the branch presence in the tree
   bool errorGettingBranches = false;
@@ -282,7 +292,7 @@ int BeamCalBkgParam::setBkgDistr(const BCPadEnergies::BeamCalSide_t bc_side)
     // Parameters of energy deposition in a pad:
     PadEdepRndPar_t pep = (BCPadEnergies::kLeft == bc_side ? 
                            m_padParLeft->at(ip) : m_padParRight->at(ip));
-    vunr.push_back(NULL);
+    vunr.push_back(nullptr);
     //TF1 *func_pad_edep = new TF1("fedep", "gaus(0)/x", pep.minm, pep.maxm);
     // if chi2 is good enough we want to initialise our unuran randomiser
     if (pep.chi2 <= 200. && pep.par1 >= 2*pep.par2) {

--- a/source/BeamCalReco/src/BeamCalBkgParam.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgParam.cpp
@@ -6,43 +6,33 @@
 * @date 2015-06-12
 */
 
-
-#include "BeamCalBkg.hh"
 #include "BeamCalBkgParam.hh"
-#include "BeamCalGeoCached.hh"
 #include "BCPadEnergies.hh"
 #include "BCRootUtilities.hh"
-
+#include "BeamCalBkg.hh"
+#include "BeamCalGeo.hh"
 
 // ----- include for verbosity dependent logging ---------
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <marlin/ProcessorEventSeeder.h>
-#include <marlin/Global.h>
 
 // ROOT
-#include <TMatrixD.h>
 #include <TTree.h>
 #include <TFile.h>
 #include <TF1.h>
 #include <TRandom3.h>
-#include <TUnuran.h>
-#include <TUnuranContDist.h>
 #include <TMath.h>
 #include <RVersion.h>
 
 #include <algorithm>
-#include <iomanip>
 #include <iostream>
 #include <map>
-#include <set>
 
 using std::vector;
 using std::string;
 using std::map;
 
-using marlin::Global;
 
 BeamCalBkgParam::BeamCalBkgParam(const string& bg_method_name, 
                      const BeamCalGeo *BCG) : BeamCalBkg(bg_method_name, BCG),

--- a/source/BeamCalReco/src/BeamCalBkgPregen.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgPregen.cpp
@@ -13,22 +13,15 @@
 #include "BeamCalBkgPregen.hh"
 #include "BeamCalGeoCached.hh"
 #include "BCPadEnergies.hh"
-#include "BCRootUtilities.hh"
-
 
 // ----- include for verbosity dependent logging ---------
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <marlin/ProcessorEventSeeder.h>
 #include <marlin/Global.h>
 
 // ROOT
 #include <TChain.h>
-#include <TMatrixD.h>
-#include <TTree.h>
-#include <TFile.h>
-#include <TF1.h>
 #include <TRandom3.h>
 
 #include <algorithm>
@@ -40,8 +33,6 @@
 using std::vector;
 using std::string;
 using std::map;
-
-using marlin::Global;
 
 BeamCalBkgPregen::BeamCalBkgPregen(const string& bg_method_name, 
                      const BeamCalGeo *BCG) 

--- a/source/BeamCalReco/src/BeamCalBkgPregen.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgPregen.cpp
@@ -9,10 +9,11 @@
 * to split into separate class for pregenerated background
 *
 */
-#include "BeamCalBkg.hh"
 #include "BeamCalBkgPregen.hh"
-#include "BeamCalGeoCached.hh"
 #include "BCPadEnergies.hh"
+#include "BeamCalBkg.hh"
+#include "BeamCalGeo.hh"
+#include "BeamCalGeoCached.hh"
 
 // ----- include for verbosity dependent logging ---------
 #include <streamlog/loglevels.h>
@@ -25,23 +26,23 @@
 #include <TRandom3.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <map>
 #include <set>
+#include <stdexcept>
 
 using std::vector;
 using std::string;
 using std::map;
 
-BeamCalBkgPregen::BeamCalBkgPregen(const string& bg_method_name, 
-                     const BeamCalGeo *BCG) 
-		 :BeamCalBkg(bg_method_name, BCG), 
-		  m_listOfBunchCrossingsLeft(vector<BCPadEnergies*>()),
-		  m_listOfBunchCrossingsRight(vector<BCPadEnergies*>()),
-		  m_backgroundBX(NULL),
-		  m_numberForAverage(1)
-{
+BeamCalBkgPregen::BeamCalBkgPregen(const string& bg_method_name, const BeamCalGeo* BCG)
+    : BeamCalBkg(bg_method_name, BCG),
+      m_listOfBunchCrossingsLeft(vector<BCPadEnergies*>()),
+      m_listOfBunchCrossingsRight(vector<BCPadEnergies*>()),
+      m_backgroundBX(nullptr),
+      m_numberForAverage(1) {
   streamlog_out(MESSAGE) << "Initialising BeamCal background with \""
 			 << bg_method_name << "\" method" << std::endl;
 }
@@ -73,12 +74,12 @@ void BeamCalBkgPregen::init(vector<string> &bg_files, const int n_bx)
 
   for (std::vector<std::string>::iterator file = bg_files.begin(); file != bg_files.end(); ++file) {
     streamlog_out(DEBUG1) << *file << std::endl;
-    m_backgroundBX->Add(TString(*file));
+    m_backgroundBX->Add((*file).c_str());
   }
 
   //Ready the energy deposit vectors for the tree
-  m_BeamCalDepositsLeft=NULL;
-  m_BeamCalDepositsRight=NULL;
+  m_BeamCalDepositsLeft  = nullptr;
+  m_BeamCalDepositsRight = nullptr;
 
   m_backgroundBX->SetBranchAddress("vec_left" , &m_BeamCalDepositsLeft);
   m_backgroundBX->SetBranchAddress("vec_right", &m_BeamCalDepositsRight);
@@ -130,8 +131,8 @@ void BeamCalBkgPregen::init(vector<string> &bg_files, const int n_bx)
   //Now divide by ten, to get the average distributions...
   m_BeamCalAverageLeft ->scaleEnergies(1./double(m_numberForAverage));
   m_BeamCalAverageRight->scaleEnergies(1./double(m_numberForAverage));
-  Double_t totalEnergyMean = m_BeamCalAverageLeft->getTotalEnergy();
-  Double_t varEn(0.0);
+  double totalEnergyMean = m_BeamCalAverageLeft->getTotalEnergy();
+  double varEn(0.0);
   for (int l = 0; l < m_numberForAverage;++l) {
     varEn += (m_listOfBunchCrossingsRight[l]->getTotalEnergy() - totalEnergyMean) * (m_listOfBunchCrossingsRight[l]->getTotalEnergy() - totalEnergyMean);
   }//histograms
@@ -171,11 +172,11 @@ BCPadEnergies* BeamCalBkgPregen::getBeamCalErrors(const BCPadEnergies *averages,
 
   BCPadEnergies * BCPErrors = new BCPadEnergies(m_BCG);
   for (int i = 0; i < m_BCG->getPadsPerBeamCal()  ;++i) {
-    Double_t mean(averages->getEnergy(i));
-    Double_t variance(0);
-    Double_t nHistos(m_numberForAverage);
+    double mean(averages->getEnergy(i));
+    double variance(0);
+    double nHistos(m_numberForAverage);
     for (int l = 0; l < nHistos;++l) {
-      Double_t energy( singles[l]->getEnergy(i) );
+      double energy(singles[l]->getEnergy(i));
       variance += ( energy - mean ) * ( energy - mean );
     }//histograms
     variance /= nHistos;

--- a/source/BeamCalReco/src/BeamCalCluster.cpp
+++ b/source/BeamCalReco/src/BeamCalCluster.cpp
@@ -2,6 +2,7 @@
 #include "BCPadEnergies.hh"
 
 #include <iomanip>
+#include <utility>
 
 //void BeamCalCluster::addPads(const BCPadEnergies& /*bcp*/){}
 

--- a/source/BeamCalReco/src/BeamCalFitShower.cpp
+++ b/source/BeamCalReco/src/BeamCalFitShower.cpp
@@ -11,6 +11,7 @@
 #include "BeamCalGeo.hh"
 #include "BeamCalPadGeometry.hh"
 
+#include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
 // ROOT
@@ -18,9 +19,10 @@
 #include "Minuit2/Minuit2Minimizer.h"
 #include "Math/Functor.h"
 
+#include <cmath>
 #include <iostream>
 #include <numeric>
-#include <cmath>
+#include <utility>
 
 using std::vector;
 using std::pair;
@@ -29,22 +31,20 @@ using std::pair;
 //                    BeamCalFitShower methods                     //
 //=================================================================//
 
-BeamCalFitShower::BeamCalFitShower(vector<EdepProfile_t*> &vep, 
-		    const BCPadEnergies::BeamCalSide_t bc_side) :
-                                  m_vep(vep),
-				  m_spotPads(vector<EdepProfile_t*>()),
-				  m_covInv(vector<double>()),
-				  m_spotEint(vector<double>()),
-				  m_BCG(NULL),
-				  m_BCbackground(NULL),
-				  m_BCside(bc_side),
-				  m_rhom(9.3),
-				  m_enTowerLimit(0.),
-				  m_towerChi2Limit(1.),
-				  m_startLayer(1),
-				  m_countingLayer(1),
-				  m_flagUncorr(false)
-{
+BeamCalFitShower::BeamCalFitShower(vector<EdepProfile_t*>& vep, const BCPadEnergies::BeamCalSide_t bc_side)
+    : m_vep(vep),
+      m_spotPads(vector<EdepProfile_t*>()),
+      m_covInv(vector<double>()),
+      m_spotEint(vector<double>()),
+      m_BCG(nullptr),
+      m_BCbackground(nullptr),
+      m_BCside(bc_side),
+      m_rhom(9.3),
+      m_enTowerLimit(0.),
+      m_towerChi2Limit(1.),
+      m_startLayer(1),
+      m_countingLayer(1),
+      m_flagUncorr(false) {
   // hardcode now, make better later
   // m_rhom = 9.3; // Moliere radius (rho_M)
 }

--- a/source/BeamCalReco/src/BeamCalFitShower.cpp
+++ b/source/BeamCalReco/src/BeamCalFitShower.cpp
@@ -6,11 +6,10 @@
 * @date 2015-03-31
 */
 
-#include "BeamCalBkg.hh"
 #include "BeamCalFitShower.hh"
-#include "BeamCalPadGeometry.hh"
-#include "BeamCalGeoCached.hh"
 #include "BCRootUtilities.hh"
+#include "BeamCalGeo.hh"
+#include "BeamCalPadGeometry.hh"
 
 #include <streamlog/streamlog.h>
 
@@ -19,8 +18,6 @@
 #include "Minuit2/Minuit2Minimizer.h"
 #include "Math/Functor.h"
 
-#include <algorithm>
-#include <iomanip>
 #include <iostream>
 #include <numeric>
 #include <cmath>

--- a/source/BeamCalReco/src/BeamCalGeo.cpp
+++ b/source/BeamCalReco/src/BeamCalGeo.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <iomanip>
+#include <stdexcept>
 
 //Return the double[6] pointer with innerRadius, Outerradius, Phi1 and Phi2, middle radius, middle phi
 void BeamCalGeo::getPadExtents(int cylinder, int sector, double *extents) const {

--- a/source/BeamCalReco/src/BeamCalGeo.cpp
+++ b/source/BeamCalReco/src/BeamCalGeo.cpp
@@ -1,10 +1,8 @@
 #include "BeamCalGeo.hh"
 
-#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <iomanip>
-#include <iostream>
 
 //Return the double[6] pointer with innerRadius, Outerradius, Phi1 and Phi2, middle radius, middle phi
 void BeamCalGeo::getPadExtents(int cylinder, int sector, double *extents) const {

--- a/source/BeamCalReco/src/BeamCalGeoCached.cpp
+++ b/source/BeamCalReco/src/BeamCalGeoCached.cpp
@@ -5,7 +5,6 @@
 #include <gear/CalorimeterParameters.h>
 #include <gear/GearMgr.h>
 
-
 #include <cmath>
 #include <vector>
 

--- a/source/BeamCalReco/src/BeamCalGeoCached.cpp
+++ b/source/BeamCalReco/src/BeamCalGeoCached.cpp
@@ -1,16 +1,13 @@
 #include "BeamCalGeoCached.hh"
 
 #include <gear/GEAR.h>
-#include <gear/GearParameters.h>
 #include <gear/LayerLayout.h>
 #include <gear/CalorimeterParameters.h>
 #include <gear/GearMgr.h>
 
 
-#include <vector>
-#include <algorithm>
 #include <cmath>
-
+#include <vector>
 
 BeamCalGeoCached::BeamCalGeoCached(gear::GearMgr* gearMgr): m_BCPs(gearMgr->getBeamCalParameters()),
 							    m_innerRadius(m_BCPs.getExtent()[0]),

--- a/source/BeamCalReco/src/BeamCalGeoDD.cpp
+++ b/source/BeamCalReco/src/BeamCalGeoDD.cpp
@@ -1,21 +1,25 @@
 #include "BeamCalGeoDD.hh"
 
-#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Alignments.h>
 #include <DD4hep/Detector.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/Readout.h>
+#include <DDParsers/DD4hepUnits.h>
 #include <DDRec/DetectorData.h>
+#include <DDSegmentation/Segmentation.h>
+#include <DDSegmentation/SegmentationParameter.h>
 
 // ----- include for verbosity dependend logging ---------
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-
-//#include <DD4hep/UserExtension/BeamCalInfo.h>
-// Use the DDRec CalorimeterExtension, I guess?
-// Use DDSegmentation RPphi parameters? This knows about tghe inner radius, too
-
-
-#include <vector>
 #include <algorithm>
+#include <cmath>
+#include <map>
+#include <ostream>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 BeamCalGeoDD::BeamCalGeoDD(dd4hep::Detector const& theDetector, std::string const& detectorName,
                            std::string const& colName): m_BeamCal(theDetector.detector(detectorName)),
@@ -46,8 +50,7 @@ BeamCalGeoDD::BeamCalGeoDD(dd4hep::Detector const& theDetector, std::string cons
   const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer>& layers= theExtension->layers;
 
   m_layers = layers.size();
-  for (size_t i = 0; i < layers.size(); i++) {
-    const dd4hep::rec::LayeredCalorimeterStruct::Layer & theLayer = layers.at(i);
+  for (auto const& theLayer : layers) {
     //no inner thickness means no sensitive detector, like the old graphite layer
     if ( theLayer.inner_thickness == 0.0 ) {
       m_layers--;

--- a/source/BeamCalReco/src/BeamCalGeoDD.cpp
+++ b/source/BeamCalReco/src/BeamCalGeoDD.cpp
@@ -1,6 +1,7 @@
 #include "BeamCalGeoDD.hh"
 
 #include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Detector.h>
 #include <DDRec/DetectorData.h>
 
 // ----- include for verbosity dependend logging ---------
@@ -12,8 +13,6 @@
 // Use the DDRec CalorimeterExtension, I guess?
 // Use DDSegmentation RPphi parameters? This knows about tghe inner radius, too
 
-
-class BeamCalInfo;
 
 #include <vector>
 #include <algorithm>

--- a/source/BeamCalReco/src/BeamCalGeoGear.cpp
+++ b/source/BeamCalReco/src/BeamCalGeoGear.cpp
@@ -1,15 +1,11 @@
 #include "BeamCalGeoGear.hh"
 
-#include <gear/GEAR.h>
-#include <gear/GearParameters.h>
 #include <gear/LayerLayout.h>
 #include <gear/CalorimeterParameters.h>
 #include <gear/GearMgr.h>
 
-
-#include <vector>
-#include <algorithm>
 #include <cmath>
+#include <vector>
 
 BeamCalGeoGear::BeamCalGeoGear(gear::GearMgr* gearMgr): m_BCPs(gearMgr->getBeamCalParameters()) {
 }

--- a/source/BeamCalReco/src/BeamCalPadGeometry.cpp
+++ b/source/BeamCalReco/src/BeamCalPadGeometry.cpp
@@ -10,8 +10,9 @@
 #include "BeamCalPadGeometry.hh"
 
 #include <algorithm>
-#include <iostream>
 #include <cmath>
+#include <iostream>
+#include <memory>
 
 using std::vector;
 using std::pair;

--- a/source/BeamCalReco/src/BeamCalPadGeometry.cpp
+++ b/source/BeamCalReco/src/BeamCalPadGeometry.cpp
@@ -10,9 +10,7 @@
 #include "BeamCalPadGeometry.hh"
 
 #include <algorithm>
-#include <iomanip>
 #include <iostream>
-#include <numeric>
 #include <cmath>
 
 using std::vector;

--- a/source/LumiCalReco/include/ClusterClass.h
+++ b/source/LumiCalReco/include/ClusterClass.h
@@ -10,6 +10,8 @@
 #include <memory>
 #include <string>
 
+// IWYU pragma: no_include <bits/shared_ptr.h>
+
 class GlobalMethodsClass;
 
 /* --------------------------------------------------------------------------

--- a/source/LumiCalReco/include/ClusterClass.h
+++ b/source/LumiCalReco/include/ClusterClass.h
@@ -1,17 +1,16 @@
 #ifndef ClusterClass_h
 #define ClusterClass_h 1
 
-#include "GlobalMethodsClass.h"
+#include "Global.hh"
 #include "LCCluster.hh"
 #include "MCInfo.h"
 
-#include <map>
+#include <algorithm>
+#include <iosfwd>
+#include <memory>
 #include <string>
-#include <vector>
 
-namespace EVENT {
-  class MCParticle;
-}
+class GlobalMethodsClass;
 
 /* --------------------------------------------------------------------------
    class ....

--- a/source/LumiCalReco/include/GlobalMethodsClass.h
+++ b/source/LumiCalReco/include/GlobalMethodsClass.h
@@ -1,25 +1,17 @@
 #ifndef GlobalMethodsClass_H
 #define GlobalMethodsClass_H 1
 
-#include "Global.hh"
-
-#include <gear/GEAR.h>
-#include <gear/GearParameters.h>
-#include <gear/CalorimeterParameters.h>
-#include <gear/LayerLayout.h>
-#include <gear/GearMgr.h>
-
-#include <marlin/ProcessorMgr.h>
-#include <marlin/CMProcessor.h>
-#include <marlin/Processor.h>
-#include <marlin/ProcessorParameter.h>
-#include <marlin/StringParameters.h>
-
-
 #include <map>
 #include <string>
+#include <tuple>
+
+class LCCluster;
 
 class TGeoHMatrix;
+
+namespace marlin {
+  class Processor;
+}
 
 namespace IMPL {
   class ClusterImpl;

--- a/source/LumiCalReco/include/LCCluster.hh
+++ b/source/LumiCalReco/include/LCCluster.hh
@@ -2,10 +2,11 @@
 #define LCCluster_hh 1
 
 #include "GlobalMethodsClass.h"
-#include "LumiCalHit.hh"
+#include "Global.hh"
 
 #include <cmath>
 #include <ostream>
+
 
 class VirtualCluster;
 

--- a/source/LumiCalReco/include/LCCluster.hh
+++ b/source/LumiCalReco/include/LCCluster.hh
@@ -5,7 +5,10 @@
 #include "Global.hh"
 
 #include <cmath>
+#include <memory> // IWYU pragma: keep
 #include <ostream>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
 
 
 class VirtualCluster;

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -19,23 +19,16 @@
 
 #include "GlobalMethodsClass.h"
 #include "LCCluster.hh"
-#include "LumiCalHit.hh"
-#include "ProjectionInfo.hh"
-#include "VirtualCluster.hh"
 
 #include <UTIL/CellIDDecoder.h>
 
-#include <streamlog/loglevels.h>
-#include <streamlog/streamlog.h>
-
 #include <string>
-#include <map>
 #include <memory>
-#include <vector>
 
 namespace EVENT {
   class CalorimeterHit;
   class LCEvent;
+  class LCCollection;
 }
 
 class LumiCalClustererClass {

--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -85,7 +85,7 @@ protected:
   MapIntInt    _numHitsInArm;
   //  VInt _armsToCluster;
 
-  std::unique_ptr<CellIDDecoder<CalorimeterHit>> _mydecoder{};
+  std::unique_ptr<UTIL::CellIDDecoder<EVENT::CalorimeterHit>> _mydecoder{};
 
   GlobalMethodsClass _gmc;
 
@@ -96,7 +96,7 @@ protected:
   int	getCalHits( EVENT::LCEvent * evt,
 		    MapIntMapIntVCalHit & calHits );
 
-  LCCollection* createCaloHitCollection(LCCollection* simCaloHitCollection) const;
+  EVENT::LCCollection* createCaloHitCollection(EVENT::LCCollection* simCaloHitCollection) const;
 
   int	buildClusters(	MapIntVCalHit const& calHits,
 			MapIntCalHit & calHitsCellIdGlobal,

--- a/source/LumiCalReco/include/MCInfo.h
+++ b/source/LumiCalReco/include/MCInfo.h
@@ -1,7 +1,6 @@
 #ifndef MCInfo_h
 #define MCInfo_h 1
 
-#include <cstddef>
 #include <memory>
 #include <ostream>
 

--- a/source/LumiCalReco/include/MCInfo.h
+++ b/source/LumiCalReco/include/MCInfo.h
@@ -1,8 +1,10 @@
 #ifndef MCInfo_h
 #define MCInfo_h 1
 
-#include <memory>
+#include <memory>  // IWYU pragma: keep
 #include <ostream>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
 
 class GlobalMethodsClass;
 namespace EVENT{

--- a/source/LumiCalReco/include/MarlinLumiCalClusterer.h
+++ b/source/LumiCalReco/include/MarlinLumiCalClusterer.h
@@ -1,19 +1,24 @@
 #ifndef MarlinLumiCalClusterer_
 #define MarlinLumiCalClusterer_
-#include <marlin/Global.h>
-#include "Global.hh"
 
 #include "GlobalMethodsClass.h"
 #include "LumiCalClusterer.h"
 #include "OutputManagerClass.h"
 
-class ClusterClass;
-
 // Marlin classes:
 #include <marlin/Processor.h>
 
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+class LCCluster;
+class ClusterClass;
+
 namespace EVENT{
   class LCEvent;
+  class LCRunHeader;
 }
 
 namespace IMPL {

--- a/source/LumiCalReco/include/OutputManagerClass.h
+++ b/source/LumiCalReco/include/OutputManagerClass.h
@@ -11,7 +11,6 @@ class TTree;
 
 #include <map>
 #include <string>
-#include <vector>
 
 class OutputManagerClass {
 

--- a/source/LumiCalReco/include/ProjectionInfo.hh
+++ b/source/LumiCalReco/include/ProjectionInfo.hh
@@ -1,8 +1,10 @@
 #ifndef ProjectionInfo_hh
 #define ProjectionInfo_hh 1
 
-#include <memory>
+#include <memory> // IWYU pragma: keep
 #include <set>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
 
 namespace EVENT{
   class CalorimeterHit;

--- a/source/LumiCalReco/include/SuperTrueClusterWeights.hh
+++ b/source/LumiCalReco/include/SuperTrueClusterWeights.hh
@@ -1,9 +1,9 @@
 #ifndef SuperTrueClusterWeights_hh
 #define SuperTrueClusterWeights_hh 1
 
-#include "LCCluster.hh"
 #include <string>
 
+class LCCluster;
 
 /* --------------------------------------------------------------------------
    class and sort rule for computing weights required for assignement of
@@ -14,8 +14,8 @@ class SuperTrueClusterWeights {
 public:
   SuperTrueClusterWeights(int superClusterIdNow,
 			  int trueClusterIdNow,
-			  LCCluster superClusterCM,
-			  LCCluster trueClusterCM);
+			  LCCluster const& superClusterCM,
+			  LCCluster const& trueClusterCM);
 
   double distance2D(double *pos1, double *pos2);
   void	 setWeight(std::string weightMethod);

--- a/source/LumiCalReco/src/ClusterClass.cpp
+++ b/source/LumiCalReco/src/ClusterClass.cpp
@@ -1,15 +1,13 @@
-
-#include "Global.hh"
-
 #include "ClusterClass.h"
 
-#include <EVENT/MCParticle.h>
+#include "Global.hh"
+#include "GlobalMethodsClass.h"
 
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <cmath>
 #include <iomanip>
+#include <ostream>
 
 using namespace streamlog;
 

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -9,29 +9,49 @@
 
 #ifdef FCAL_WITH_DD4HEP
 
-#include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Alignments.h>
+#include <DD4hep/DetElement.h>
 #include <DD4hep/Detector.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/Readout.h>
+#include <DD4hep/Segmentations.h>
+#include <DDParsers/DD4hepUnits.h>
 #include <DDRec/DetectorData.h>
+#include <DDSegmentation/Segmentation.h>
+#include <DDSegmentation/SegmentationParameter.h>
 
 #endif
 
 #include <marlin/CMProcessor.h>
 #include <marlin/Global.h>
+#include <marlin/Processor.h>
+#include <marlin/ProcessorParameter.h>
+#include <marlin/StringParameters.h>
 
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
 #include <IMPL/ClusterImpl.h>
 #include <IMPL/ReconstructedParticleImpl.h>
+#include <LCIOSTLTypes.h>
 
 using streamlog::MESSAGE;
 
-#include <map>
-#include <string>
+#include <TGeoMatrix.h>
+
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
 
 // utility copied from marlin 
 template <class T>

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -1,21 +1,22 @@
 
 #include "GlobalMethodsClass.h"
-#include "MarlinLumiCalClusterer.h"
+#include "LCCluster.hh"
+#include "LumiCalHit.hh"
 
-#include <gear/GEAR.h>
-#include <gear/GearParameters.h>
 #include <gear/LayerLayout.h>
 #include <gear/CalorimeterParameters.h>
 #include <gear/GearMgr.h>
 
 #ifdef FCAL_WITH_DD4HEP
 
-#include <DD4hep/Detector.h>
 #include <DD4hep/DD4hepUnits.h>
+#include <DD4hep/Detector.h>
 #include <DDRec/DetectorData.h>
 
 #endif
 
+#include <marlin/CMProcessor.h>
+#include <marlin/Global.h>
 
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
@@ -27,7 +28,6 @@ using streamlog::MESSAGE;
 
 #include <map>
 #include <string>
-#include <sstream>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -3,6 +3,7 @@
 #include "VirtualCluster.hh"
 
 #include <iomanip>
+#include <memory>
 
 LCCluster::LCCluster() {}
 

--- a/source/LumiCalReco/src/LCCluster.cpp
+++ b/source/LumiCalReco/src/LCCluster.cpp
@@ -1,7 +1,7 @@
 #include "LCCluster.hh"
+#include "LumiCalHit.hh"
 #include "VirtualCluster.hh"
 
-#include <iostream>
 #include <iomanip>
 
 LCCluster::LCCluster() {}

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -8,21 +8,18 @@
    ============================================================================ */
 #include "LumiCalClusterer.h"
 
-#include <IMPL/CalorimeterHitImpl.h>
-
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
 
 namespace EVENT{
   class LCEvent;
 }
 
+#include <iomanip>
+#include <iostream>
 #include <map>
 #include <string>
-#include <vector>
-#include <cmath>
-#include <iostream>
-#include <iomanip>
-
-
+#include <utility>
 
 /* ============================================================================
    Constructor

--- a/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
@@ -1,24 +1,30 @@
 //Local
 #include "Distance2D.hh"
+#include "Global.hh"
+#include "GlobalMethodsClass.h"
+#include "LCCluster.hh"
 #include "LumiCalClusterer.h"
 #include "LumiCalHit.hh"
+#include "ProjectionInfo.hh"
 #include "SortingFunctions.hh"
 using LCHelper::distance2D;
 
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-// stdlib
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <vector>
 #include <iomanip>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
-
-#ifdef FCAL_WITH_DD4HEP
-#include <DD4hep/DD4hepUnits.h>
-#endif
+// IWYU pragma: no_include <bits/shared_ptr.h>
+// IWYU pragma: no_include <ext/alloc_traits.h>
 
 /* --------------------------------------------------------------------------
    calculate weight for cluster CM according to different methods

--- a/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_auxiliary.cpp
@@ -1,8 +1,12 @@
 //Local
-#include "SortingFunctions.hh"
-#include "LumiCalClusterer.h"
 #include "Distance2D.hh"
+#include "LumiCalClusterer.h"
+#include "LumiCalHit.hh"
+#include "SortingFunctions.hh"
 using LCHelper::distance2D;
+
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
 
 // stdlib
 #include <algorithm>

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters.cpp
@@ -1,24 +1,31 @@
 // Local
-#include "Global.hh"
-#include "LumiCalClusterer.h"
-#include "SortingFunctions.hh"
 #include "Distance2D.hh"
+#include "Global.hh"
+#include "LCCluster.hh"
+#include "LumiCalClusterer.h"
+#include "LumiCalHit.hh"
+#include "SortingFunctions.hh"
+#include "VirtualCluster.hh"
 using LCHelper::distance2D;
+
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
 
 // Root
 #include <TF1.h>
-#include <TH1F.h>
-#include <TString.h>
-// LCIO
-#include <IMPL/CalorimeterHitImpl.h>
+#include <TH1.h>
+
 // stdlib
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <map>
+#include <memory>
+#include <ostream>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
-
-
 
 /* =========================================================================
    LumiCalClustererClass :: buildClusters

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters.cpp
@@ -2,7 +2,7 @@
 #include "Distance2D.hh"
 #include "Global.hh"
 #include "LCCluster.hh"
-#include "LumiCalClusterer.h"
+#include "LumiCalClusterer.h"  // IWYU pragma: associated
 #include "LumiCalHit.hh"
 #include "SortingFunctions.hh"
 #include "VirtualCluster.hh"
@@ -18,6 +18,7 @@ using LCHelper::distance2D;
 // stdlib
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <iomanip>
 #include <map>
 #include <memory>
@@ -26,6 +27,10 @@ using LCHelper::distance2D;
 #include <string>
 #include <utility>
 #include <vector>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
+// IWYU pragma: no_include <ext/alloc_traits.h>
+// IWYU pragma: no_include <Math/ParamFunctor.h>
 
 /* =========================================================================
    LumiCalClustererClass :: buildClusters
@@ -112,14 +117,14 @@ int LumiCalClustererClass::buildClusters(MapIntVCalHit const& calHits, MapIntCal
   // 3. for ShowerPeak layers optionally split hits according to value <middleEnergyHitBound>
 
   for (MapIntVCalHit::const_iterator calHitsIt = calHits.begin(); calHitsIt!=calHits.end(); ++calHitsIt) {
-    size_t numHitsInLayer = (int)(calHitsIt->second.size());
+    std::size_t numHitsInLayer    = (int)(calHitsIt->second.size());
     int layerNow = calHitsIt->first;
     isShowerPeakLayer[ layerNow ] = ( (int)numHitsInLayer > minNumElementsInShowerPeakLayer )? 1 : 0;
 #if _CLUSTER_BUILD_DEBUG == 1
     if( isShowerPeakLayer[ layerNow ] == 1 )
       streamlog_out(DEBUG3) <<"\t"<< layerNow <<"\t nhits("<< numHitsInLayer <<")\n";
 #endif
-    for(size_t j=0; j<numHitsInLayer; j++){
+    for (std::size_t j = 0; j < numHitsInLayer; j++) {
       int       cellIdHit = (int)calHitsIt->second[j]->getCellID0();
       double    cellEngy = (double)calHitsIt->second[j]->getEnergy();
       if( cellEngy >= _hitMinEnergy ){
@@ -418,13 +423,13 @@ int LumiCalClustererClass::buildClusters(MapIntVCalHit const& calHits, MapIntCal
        -------------------------------------------------------------------------- */
 
     // initialize the layer-averaging position/energy maps
-    for(size_t layerN = 0; layerN < engyPosCMLayer[clusterId].size(); layerN++) {
+    for (std::size_t layerN = 0; layerN < engyPosCMLayer[clusterId].size(); layerN++) {
       const int layerNow = thisLayer[clusterId][layerN];
       layerToPosX[layerNow] = layerToPosY[layerNow] = layerToEngy[layerNow] = 0.;
     }
 
     // fill the maps with energy-weighted positions
-    for(size_t layerN = 0; layerN < engyPosCMLayer[clusterId].size(); layerN++) {
+    for (std::size_t layerN = 0; layerN < engyPosCMLayer[clusterId].size(); layerN++) {
       const int layerNow = thisLayer[clusterId][layerN];
       /*(BP) FIX:
        *  it should be weighted with WeightingMethod
@@ -442,7 +447,7 @@ int LumiCalClustererClass::buildClusters(MapIntVCalHit const& calHits, MapIntCal
 
     // fill histograms of x(z) and y(z) of the CM positions
     layerToPosXYIterator = layerToPosX.begin();
-    for(size_t layerN = 0; layerN < layerToPosX.size(); layerN++, layerToPosXYIterator++) {
+    for (std::size_t layerN = 0; layerN < layerToPosX.size(); layerN++, layerToPosXYIterator++) {
       const int layerNow = (int)(*layerToPosXYIterator).first;
 
       // get back to units of position

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
@@ -1,23 +1,27 @@
 // Local
-#include "LumiCalClusterer.h"
-#include "LCCluster.hh"
-#include "SortingFunctions.hh"
-#include "Global.hh"
-#include "ProjectionInfo.hh"
 #include "Distance2D.hh"
+#include "Global.hh"
+#include "GlobalMethodsClass.h"
+#include "LCCluster.hh"
+#include "LumiCalClusterer.h"
+#include "LumiCalHit.hh"
+#include "ProjectionInfo.hh"
+#include "SortingFunctions.hh"
+#include "VirtualCluster.hh"
 using LCHelper::distance2D;
 
-//LCIO
-#include <IMPL/CalorimeterHitImpl.h>
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
+
 // Stdlib
-#include <map>
-#include <vector>
-#include <iomanip>
 #include <algorithm>
 #include <cassert>
-#include <stdexcept>
-
-
+#include <cmath>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <utility>
+#include <vector>
 
 /* =========================================================================
    LumiCalClustererClass :: initialClusterBuild

--- a/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_buildClusters_auxiliary.cpp
@@ -17,11 +17,15 @@ using LCHelper::distance2D;
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <ostream>
 #include <utility>
 #include <vector>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
+// IWYU pragma: no_include <ext/alloc_traits.h>
 
 /* =========================================================================
    LumiCalClustererClass :: initialClusterBuild
@@ -315,7 +319,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
     sort(clusterIdEngyV2.begin(), clusterIdEngyV2.end(), clusterCMEnergyCmpAsc<VVDouble::value_type>);
 
     // copy the Ids that are now in order to a std::vector
-    for(size_t j=0; j<clusterIdEngyV2.size(); j++)
+    for (std::size_t j = 0; j < clusterIdEngyV2.size(); j++)
       clusterIdV.push_back( (int)clusterIdEngyV2[j][1] );
 
     // cleanUp
@@ -333,7 +337,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
       }
 
       // compute distance to neighboring clusters
-      for(size_t j=1; j<clusterIdV.size(); j++){
+      for(std::size_t j=1; j<clusterIdV.size(); j++){
 	clusterId = clusterIdV[j];
 
 	const double distanceCM = distance2D(clusterCM[clusterIdV[0]].getPosition(),clusterCM[clusterId].getPosition());
@@ -367,7 +371,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
 	const int clusterId1 = clusterIdV[0];
 	const int clusterId2 = maxElement->first;
 
-	for(size_t j=0; j<clusterIdToCellId[clusterId1].size(); j++){
+	for(std::size_t j=0; j<clusterIdToCellId[clusterId1].size(); j++){
 	  // add hit from clusterIdToCellId with clusterId to one with maxWDClusterId
 	  const int cellIdHit = clusterIdToCellId[clusterId1][j];
 	  clusterIdToCellId[clusterId2].push_back(cellIdHit);
@@ -414,7 +418,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
     sort(clusterIdEngyV2.begin(), clusterIdEngyV2.end(), clusterCMEnergyCmpDesc<VVDouble::value_type>);
 
     // copy the Ids that are now in order to a std::vector
-    for(size_t j=0; j<clusterIdEngyV2.size(); j++)
+    for (std::size_t j = 0; j < clusterIdEngyV2.size(); j++)
       clusterIdV.push_back( (int)clusterIdEngyV2[j][1] );
 
     // cleanUp
@@ -431,7 +435,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
       double CM1[2] = { highestCluster.getX(), highestCluster.getY() };
 
       // compute distance to neighboring clusters
-      for(size_t j=1; j<clusterIdV.size(); j++){
+      for(std::size_t j=1; j<clusterIdV.size(); j++){
 
 	const int clusterIdJ = clusterIdV[j];
 	LCCluster const& thisCluster = clusterCM[clusterIdJ];
@@ -468,7 +472,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
 	const int clusterId1 = maxElement->first;
 	const int clusterId2 = clusterIdV[0];
 
-	for(size_t j=0; j<clusterIdToCellId[clusterId1].size(); j++){
+	for(std::size_t j=0; j<clusterIdToCellId[clusterId1].size(); j++){
 	  // add hit from clusterIdToCellId with clusterId to one with maxWDClusterId
 	  const int cellIdHit = clusterIdToCellId[clusterId1][j];
 	  clusterIdToCellId[clusterId2].push_back(cellIdHit);
@@ -550,7 +554,7 @@ int LumiCalClustererClass::initialClusterBuild(MapIntCalHit const& calHitsCellId
 	const int clusterId1 = smallClusterIdV[j];
 	const int clusterId2 = maxElement->first;
 
-	for(size_t k=0; k<clusterIdToCellId[clusterId1].size(); k++){
+	for(std::size_t k=0; k<clusterIdToCellId[clusterId1].size(); k++){
 	  // add hit from clusterIdToCellId with clusterId to one with maxWDClusterId
 	  const int cellIdHit = clusterIdToCellId[clusterId1][k];
 	  clusterIdToCellId[clusterId2].push_back(cellIdHit);
@@ -1609,10 +1613,10 @@ int LumiCalClustererClass::engyInMoliereCorrections(MapIntCalHit const& calHitsC
 
       std::vector< int > const& cellIds = superClusterIdToCellId[superClusterIdBad];
       //Find the clusters closest to the previously rejected Hits
-      for(size_t hitNow = 0; hitNow < cellIds.size(); hitNow++) {
-	const int cellIdHit = cellIds[hitNow];
+      for (std::size_t hitNow = 0; hitNow < cellIds.size(); hitNow++) {
+        const int cellIdHit = cellIds[hitNow];
 
-	std::map < int , double > weightedDistanceV;
+        std::map<int, double> weightedDistanceV;
         const auto& thisHit = calHitsCellIdGlobal.at(cellIdHit);
 
 	int numSuperClustersGood = superClusterAccepted.size();

--- a/source/LumiCalReco/src/LumiCalClusterer_clusterMerger.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_clusterMerger.cpp
@@ -5,12 +5,6 @@
 #include <map>
 #include <vector>
 #include <algorithm>
-#include <iostream>
-#include <iomanip>
-//Forward Declaration
-namespace IMPL{
-  class CalorimeterHitImpl;
-}
 
 void LumiCalClustererClass::clusterMerger(MapIntVDouble& clusterIdToCellEngy,
                                           MapIntVInt& clusterIdToCellId,

--- a/source/LumiCalReco/src/LumiCalClusterer_clusterMerger.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_clusterMerger.cpp
@@ -1,10 +1,13 @@
 // Local
-#include "SuperTrueClusterWeights.hh"
+#include "Global.hh"
+#include "LCCluster.hh"
 #include "LumiCalClusterer.h"
+#include "SuperTrueClusterWeights.hh"
 // Stdlib
-#include <map>
-#include <vector>
 #include <algorithm>
+#include <map>
+#include <utility>
+#include <vector>
 
 void LumiCalClustererClass::clusterMerger(MapIntVDouble& clusterIdToCellEngy,
                                           MapIntVInt& clusterIdToCellId,

--- a/source/LumiCalReco/src/LumiCalClusterer_energyCorrections.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_energyCorrections.cpp
@@ -1,19 +1,15 @@
 //Local
-#include "LumiCalClusterer.h"
 #include "Distance2D.hh"
+#include "LumiCalClusterer.h"
+#include "LumiCalHit.hh"
 using LCHelper::distance2D;
 //Root
-#include <TH1F.h>
-//LCIO
-#include <IMPL/CalorimeterHitImpl.h>
+#include <TH1.h>
 // stdlib
-#include <map>
-#include <vector>
 #include <cmath>
-//Forward Declarations
-namespace IMPL{
-  class CalorimeterHitImpl;
-}
+#include <map>
+#include <utility>
+#include <vector>
 
 void LumiCalClustererClass::energyCorrections(MapIntVInt& superClusterIdToCellId,
                                               MapIntVDouble& superClusterIdToCellEngy,

--- a/source/LumiCalReco/src/LumiCalClusterer_energyCorrections.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_energyCorrections.cpp
@@ -1,5 +1,7 @@
 //Local
 #include "Distance2D.hh"
+#include "Global.hh"
+#include "LCCluster.hh"
 #include "LumiCalClusterer.h"
 #include "LumiCalHit.hh"
 using LCHelper::distance2D;
@@ -8,8 +10,12 @@ using LCHelper::distance2D;
 // stdlib
 #include <cmath>
 #include <map>
+#include <memory>
+#include <string>
 #include <utility>
 #include <vector>
+
+// IWYU pragma: no_include <bits/shared_ptr.h>
 
 void LumiCalClustererClass::energyCorrections(MapIntVInt& superClusterIdToCellId,
                                               MapIntVDouble& superClusterIdToCellEngy,

--- a/source/LumiCalReco/src/LumiCalClusterer_fiducialVolumeCuts.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_fiducialVolumeCuts.cpp
@@ -1,14 +1,16 @@
 //Local
+#include "LCCluster.hh"
 #include "LumiCalClusterer.h"
 
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
 // Stdlib
-#include <map>
-#include <vector>
 #include <cmath>
 #include <iostream>
+#include <map>
+#include <utility>
+#include <vector>
 
 void LumiCalClustererClass:: fiducialVolumeCuts( std::map < int , std::vector<int> > & superClusterIdToCellId,
 						 std::map < int , std::vector<double> > & superClusterIdToCellEngy,

--- a/source/LumiCalReco/src/LumiCalClusterer_fiducialVolumeCuts.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_fiducialVolumeCuts.cpp
@@ -1,6 +1,9 @@
 //Local
-#include "Global.hh"
 #include "LumiCalClusterer.h"
+
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
+
 // Stdlib
 #include <map>
 #include <vector>

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -58,7 +58,8 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
     }
 
     if (not _mydecoder) {
-      _mydecoder = std::unique_ptr<CellIDDecoder<CalorimeterHit>>(new CellIDDecoder<CalorimeterHit>(col));
+      _mydecoder =
+        std::unique_ptr<UTIL::CellIDDecoder<EVENT::CalorimeterHit>>(new UTIL::CellIDDecoder<EVENT::CalorimeterHit>(col));
     }
 
     for (int i=0; i<nHitsCol; ++i) {
@@ -172,18 +173,18 @@ int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
     }else{ return 1; }
 }
 
-LCCollection* LumiCalClustererClass::createCaloHitCollection(LCCollection* simCaloHitCollection) const {
+EVENT::LCCollection* LumiCalClustererClass::createCaloHitCollection(EVENT::LCCollection* simCaloHitCollection) const {
   streamlog_out(DEBUG7) << "Creating the CalorimeterHit collection with dummy digitization" << std::endl;
 
   const double calibrationFactor = _gmc.getCalibrationFactor();
 
-  auto caloHitCollection = new IMPL::LCCollectionVec(LCIO::CALORIMETERHIT);
-  caloHitCollection->parameters().setValue(LCIO::CellIDEncoding,
-                                           simCaloHitCollection->getParameters().getStringVal(LCIO::CellIDEncoding));
+  auto caloHitCollection = new IMPL::LCCollectionVec(EVENT::LCIO::CALORIMETERHIT);
+  caloHitCollection->parameters().setValue(EVENT::LCIO::CellIDEncoding,
+                                           simCaloHitCollection->getParameters().getStringVal(EVENT::LCIO::CellIDEncoding));
   caloHitCollection->setFlag(simCaloHitCollection->getFlag());
   for (int i = 0; i < simCaloHitCollection->getNumberOfElements(); ++i) {
     auto simHit = static_cast<EVENT::SimCalorimeterHit*>(simCaloHitCollection->getElementAt(i));
-    auto calHit = new CalorimeterHitImpl();
+    auto calHit = new IMPL::CalorimeterHitImpl();
 
     calHit->setCellID0(simHit->getCellID0());
     calHit->setCellID1(simHit->getCellID1());

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -1,19 +1,32 @@
 // Local
+#include "Global.hh"
+#include "GlobalMethodsClass.h"
 #include "LumiCalClusterer.h"
+#include "LumiCalHit.hh"
+
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
 //LCIO
+#include <EVENT/CalorimeterHit.h>
 #include <EVENT/LCCollection.h>
 #include <EVENT/LCEvent.h>
+#include <EVENT/LCIO.h>
+#include <EVENT/LCObject.h>
+#include <EVENT/LCParameters.h>
+#include <EVENT/SimCalorimeterHit.h>
 #include <Exceptions.h>
 #include <IMPL/CalorimeterHitImpl.h>
 #include <IMPL/LCCollectionVec.h>
-#include <IMPL/SimCalorimeterHitImpl.h>
+#include <UTIL/BitField64.h>
 #include <UTIL/CellIDDecoder.h>
 // Stdlib
-#include <map>
-#include <vector>
-#include <iostream>
-#include <cmath>
+#include <algorithm>
 #include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 /* --------------------------------------------------------------------------
    Loop over al hits in the LCCollection and write the hits into vectors

--- a/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer_getCalHits.cpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+// IWYU pragma: no_include <bits/shared_ptr.h>
+
 /* --------------------------------------------------------------------------
    Loop over al hits in the LCCollection and write the hits into vectors
    of CalorimeterHitImpl. Hits are split in two vectors, one for each arm
@@ -35,8 +37,7 @@
    -------------------------------------------------------------------------- */
 int LumiCalClustererClass::getCalHits(	EVENT::LCEvent * evt,
 					MapIntMapIntVCalHit & calHits) {
-
-  EVENT::LCCollection * col = NULL;
+  EVENT::LCCollection* col = nullptr;
   try {
     col = evt->getCollection(_lumiName.c_str());
   } catch (EVENT::DataNotAvailableException& e) {

--- a/source/LumiCalReco/src/MCInfo.cpp
+++ b/source/LumiCalReco/src/MCInfo.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <memory>
 
@@ -22,7 +23,8 @@ SMCInfo MCInfo::getMCParticleInfo(EVENT::MCParticle* particle, GlobalMethodsClas
 
   int pdg = particle->getPDG();
   // skip neutrinos
-  if( abs(pdg) == 12 || abs(pdg) == 14 || abs(pdg) == 16 ) return mcp; //<--- detectable ?
+  if (std::abs(pdg) == 12 || std::abs(pdg) == 14 || std::abs(pdg) == 16)
+    return mcp;  //<--- detectable ?
 
   // energy above min
   const double engy = particle->getEnergy();

--- a/source/LumiCalReco/src/MCInfo.cpp
+++ b/source/LumiCalReco/src/MCInfo.cpp
@@ -1,9 +1,13 @@
 #include "MCInfo.h"
+#include "Global.hh"
 #include "GlobalMethodsClass.h"
 
 #include <EVENT/MCParticle.h>
 
+#include <algorithm>
+#include <cmath>
 #include <iomanip>
+#include <memory>
 
 SMCInfo MCInfo::getMCParticleInfo(EVENT::MCParticle* particle, GlobalMethodsClass& gmc) {
   const double LcalZstart = gmc.GlobalParamD[GlobalMethodsClass::ZStart];

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -32,6 +32,9 @@
 #include <utility>
 #include <vector>
 
+// IWYU pragma: no_include <bits/shared_ptr.h>
+// IWYU pragma: no_include <ext/alloc_traits.h>
+
 /* >> */
 
 /// use std::bind to set first variable and use in std::sort
@@ -227,7 +230,7 @@ void MarlinLumiCalClusterer::writeRootInfo(LCEvent* evt) {
     for (MapIntPClusterClass::iterator mapIntClusterClassIt = clusterClassMap[armNow].begin();
          mapIntClusterClassIt != clusterClassMap[armNow].end(); ++mapIntClusterClassIt) {
       delete mapIntClusterClassIt->second;
-      mapIntClusterClassIt->second = NULL;
+      mapIntClusterClassIt->second = nullptr;
     }
   }
 }  // WriteRootInfo
@@ -248,7 +251,7 @@ void MarlinLumiCalClusterer::CreateClusters(std::map<int, MapIntPClusterClass>& 
     for (int jparticle = 0; jparticle < numMCParticles; jparticle++) {
       MCParticle* particle = static_cast<MCParticle*>(particles->getElementAt(jparticle));
       auto        mcInfo   = MCInfo::getMCParticleInfo(particle, gmc);
-      if (mcInfo->mcp == NULL)
+      if (mcInfo->mcp == nullptr)
         continue;
       streamlog_out(DEBUG2) << mcInfo.get() << std::endl;
       if (mcInfo->sign > 0)
@@ -390,7 +393,7 @@ void MarlinLumiCalClusterer::CreateClusters(std::map<int, MapIntPClusterClass>& 
 
   void MarlinLumiCalClusterer::storeMCParticleInfo(LCEvent* evt, int clusterInFlag) {
     int mcparticleInFlag = 0;
-    LCCollection * particles(NULL);
+    LCCollection* particles(nullptr);
     try {
       particles = evt->getCollection( "MCParticle" );
     } catch ( DataNotAvailableException &e ){
@@ -404,7 +407,7 @@ void MarlinLumiCalClusterer::CreateClusters(std::map<int, MapIntPClusterClass>& 
     for ( int jparticle=0; jparticle<numMCParticles; jparticle++ ){
       MCParticle *particle = static_cast<MCParticle*>( particles->getElementAt(jparticle) );
       auto        mcInfo   = MCInfo::getMCParticleInfo(particle, gmc);
-      if (mcInfo->mcp == NULL)
+      if (mcInfo->mcp == nullptr)
         continue;
       const double *endPoint = particle->getEndpoint();
       const double *vx = particle->getVertex();

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -2,24 +2,35 @@
 #include "MarlinLumiCalClusterer.h"
 
 #include "ClusterClass.h"
+#include "Global.hh"
+#include "LCCluster.hh"
 #include "MCInfo.h"
 
+#include <streamlog/loglevels.h>  // for DEBUG6, DEBUG7, DEBUG2
+#include <streamlog/streamlog.h>  // for streamlog_out
+
 #include <EVENT/LCCollection.h>
+#include <EVENT/LCEvent.h>
+#include <EVENT/LCIO.h>
 #include <EVENT/MCParticle.h>
+#include <Exceptions.h>
 #include <IMPL/ClusterImpl.h>
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCFlagImpl.h>
 #include <IMPL/ReconstructedParticleImpl.h>
 
-#include <TH1F.h>
-#include <TH2F.h>
-#include <TTree.h>
+#include <TH1.h>
+#include <TH2.h>
 
 #include <algorithm>
-#include <map>
-#include <vector>
-#include <iomanip>
+#include <cmath>
 #include <functional>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <utility>
+#include <vector>
 
 /* >> */
 

--- a/source/LumiCalReco/src/OutputManagerClass.cpp
+++ b/source/LumiCalReco/src/OutputManagerClass.cpp
@@ -1,17 +1,14 @@
 #include "OutputManagerClass.h"
-#include "Global.hh"
 
 #include <TFile.h>
-#include <TH1F.h>
-#include <TH2F.h>
+#include <TH1.h>
+#include <TH2.h>
 #include <TROOT.h>
 #include <TTree.h>
 
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <algorithm>
-#include <cassert>
 #include <map>
 #include <sstream>
 #include <string>

--- a/source/LumiCalReco/src/OutputManagerClass.cpp
+++ b/source/LumiCalReco/src/OutputManagerClass.cpp
@@ -1,5 +1,7 @@
 #include "OutputManagerClass.h"
 
+#include <Rtypes.h>
+#include <TAxis.h>
 #include <TFile.h>
 #include <TH1.h>
 #include <TH2.h>
@@ -9,9 +11,11 @@
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
+#include <cstdlib>
 #include <map>
 #include <sstream>
 #include <string>
+#include <utility>
 
 OutputManagerClass::OutputManagerClass()
     : HisMap1D(),
@@ -24,7 +28,7 @@ OutputManagerClass::OutputManagerClass()
       TreeDoubleV(),
       OutputRootFileName("LcalOut"),
       OutDirName("rootOut"),
-      OutputRootFile(NULL),
+      OutputRootFile(nullptr),
       Counter(),
       CounterIterator(),
       SkipNEvents(0),
@@ -45,14 +49,14 @@ void OutputManagerClass::Initialize(int treeLocOptNow, int skipNEventsNow, int n
   //	Counter["High engy cluster In positive side"] = 0;
   //	Counter["High engy cluster In negative side"] = 0;
   //	Counter["Bhabhas after selection cuts"]   = 0;
-  OutputRootFile = NULL;
+  OutputRootFile = nullptr;
   if (outFileNameNow == "")
     return;  // nothing to do
 
   TH1F*       his1;
   TH2F*       his2;
   TTree*      tree;
-  Int_t       markerCol = kRed - 4, lineCol = kAzure + 3, fillCol = kBlue - 8;
+  int         markerCol = kRed - 4, lineCol = kAzure + 3, fillCol = kBlue - 8;
   std::string hisName;
   int         numBins1;
   double      hisRange1[2];

--- a/source/LumiCalReco/src/ProjectionInfo.cpp
+++ b/source/LumiCalReco/src/ProjectionInfo.cpp
@@ -1,6 +1,8 @@
 #include "ProjectionInfo.hh"
 #include "LumiCalHit.hh"
 
+#include <memory>
+
 ProjectionInfo::ProjectionInfo (): energy (0.0), cellIdHitZ(0), newObject(true) {
   position[0] = 0.0;
   position[1] = 0.0;

--- a/source/LumiCalReco/src/SuperTrueClusterWeights.cpp
+++ b/source/LumiCalReco/src/SuperTrueClusterWeights.cpp
@@ -1,14 +1,14 @@
-#include "Distance2D.hh"
 #include "SuperTrueClusterWeights.hh"
+#include "Distance2D.hh"
+#include "LCCluster.hh"
 
+#include <algorithm>
 #include <cmath>
-#include <cassert>
-
 
 SuperTrueClusterWeights::SuperTrueClusterWeights(	int superClusterIdNow,
 							int trueClusterIdNow,
-							LCCluster superClusterCM,
-							LCCluster trueClusterCM):
+							LCCluster const& superClusterCM,
+							LCCluster const& trueClusterCM):
 
   superClusterId(superClusterIdNow),
   trueClusterId(trueClusterIdNow),

--- a/source/MarlinProcessors/include/BeamCalClusterReco.hh
+++ b/source/MarlinProcessors/include/BeamCalClusterReco.hh
@@ -1,29 +1,27 @@
 #ifndef BeamCalClusterReco_h
 #define BeamCalClusterReco_h 1
 
-#include <lcio.h>
 #include <marlin/Processor.h>
 
 #include <string>
 #include <vector>
 #include <map>
 
-class TChain;
 class TEfficiency;
-class TFile;
 class TH1;
-class TRandom3;
 class TString;
 
 class BCPCuts;
 class BCPadEnergies;
 class BCRecoObject;
-class BeamCal;
 class BeamCalGeo;
 class BeamCalBkg;
 
 namespace EVENT {
   class CalorimeterHit;
+  class LCCollection;
+  class LCEvent;
+  class LCRunHeader;
 }
 
 class BeamCalClusterReco : public marlin::Processor {

--- a/source/MarlinProcessors/include/DrawBeamCalFromDD4hep.hh
+++ b/source/MarlinProcessors/include/DrawBeamCalFromDD4hep.hh
@@ -1,25 +1,21 @@
 #ifndef DrawBeamCalFromDD4hep_h
 #define DrawBeamCalFromDD4hep_h 1
 
-#include <BCPadEnergies.hh>
-
 #include <marlin/Processor.h>
-#include <lcio.h>
 
-#include <DD4hep/Detector.h>
 #include <DD4hep/DetElement.h>
+#include <DD4hep/Segmentations.h>
 
 #include <string>
-#include <vector>
 #include <map>
 
-
-class TH1D;
-class TH2D;
-class TH3D;
 class TFile;
-class TRandom3;
 class TTree;
+
+namespace EVENT {
+  class LCEvent;
+  class LCRunHeader;
+}
 
 typedef std::map< unsigned int, double> MapIdVal;
 
@@ -70,7 +66,6 @@ class DrawBeamCalFromDD4hep : public marlin::Processor {
   int m_nEvt ;
   bool m_drawDensities;
 
-  BeamCalGeo* m_bcg;
   dd4hep::DetElement m_BeamCal{};
   dd4hep::Segmentation m_seg{};
   TFile * m_file;

--- a/source/MarlinProcessors/include/ReadBeamCal.hh
+++ b/source/MarlinProcessors/include/ReadBeamCal.hh
@@ -1,19 +1,13 @@
 #ifndef ReadBeamCal_h
 #define ReadBeamCal_h 1
 
-#include <BCPadEnergies.hh>
-
 #include <string>
-#include <vector>
 
 #include <marlin/Processor.h>
-#include <lcio.h>
 
+class BCPadEnergies;
+class BeamCalGeo;
 
-class TH1D;
-class TH2D;
-class TH3D;
-class TFile;
 class TRandom3;
 
 

--- a/source/MarlinProcessors/include/ReadBeamCal.hh
+++ b/source/MarlinProcessors/include/ReadBeamCal.hh
@@ -10,6 +10,10 @@ class BeamCalGeo;
 
 class TRandom3;
 
+namespace EVENT {
+  class LCEvent;
+  class LCRunHeader;
+}
 
 class ReadBeamCal : public marlin::Processor {
   

--- a/source/MarlinProcessors/src/BeamCalClusterReco.cpp
+++ b/source/MarlinProcessors/src/BeamCalClusterReco.cpp
@@ -259,9 +259,6 @@ void BeamCalClusterReco::init() {
 
   m_nEvt = 0;
 
-#pragma message "FIXME: Allow for possibility to use precomputed sigma file"
-#pragma message "FIXME: Need energy calibration"
-
   if ( (m_startingRings.size() != m_requiredClusterEnergy.size() ) ||
        (m_requiredClusterEnergy.size() != m_requiredRemainingEnergy.size())){
     throw WrongParameterException("== Error From BeamCalClusterReco == The number of starting rings and required" \

--- a/source/MarlinProcessors/src/BeamCalClusterReco.cpp
+++ b/source/MarlinProcessors/src/BeamCalClusterReco.cpp
@@ -7,7 +7,6 @@
 #include "BeamCal.hh"
 #include "BeamCalCluster.hh"
 #include "BCUtilities.hh"
-#include "BeamCalGeoCached.hh"
 #include "BeamCalBkg.hh"
 #include "BeamCalFitShower.hh"
 
@@ -15,7 +14,6 @@
 #include <EVENT/CalorimeterHit.h>
 #include <EVENT/LCCollection.h>
 #include <EVENT/MCParticle.h>
-#include <EVENT/ReconstructedParticle.h>
 #include <EVENT/SimCalorimeterHit.h>
 #include <IMPL/CalorimeterHitImpl.h>
 #include <IMPL/ClusterImpl.h>
@@ -30,24 +28,20 @@
 
 #include <marlin/ProcessorEventSeeder.h>
 #include <marlin/Global.h>
-#include <marlin/Exceptions.h>
 
 //ROOT
 #include <TCanvas.h>
-#include <TChain.h>
-#include <TCrown.h>
 #include <TEfficiency.h>
 #include <TFile.h>
-#include <TH2F.h>
+#include <TH2.h>
 #include <TLine.h>
+#include <TMarker.h>
+#include <TMath.h>
 #include <TPaveText.h>
 #include <TProfile.h>
-#include <TRandom3.h>
 #include <TStyle.h>
-#include <TMarker.h>
 
 //STDLIB
-#include <numeric>
 #include <iomanip>
 #include <iostream>
 #include <utility>

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -1,48 +1,46 @@
 #include "DrawBeamCalFromDD4hep.hh"
 
-#include <BeamCal.hh>
-#include <BeamCalGeoGear.hh>
-#include <BeamCalGeoCached.hh>
-#include <BCUtilities.hh>
-
 #ifdef FCAL_USE_CustomRoot
 #include <CustomRoot.hh>
 #endif
 
-
-#include "DD4hep/DD4hepUnits.h"
+#include <DD4hep/Detector.h>
+#include <DD4hep/Objects.h>
+#include <DD4hep/Readout.h>
+#include <DD4hep/Segmentations.h>
+#include <DDParsers/DD4hepUnits.h>
+#include <DDSegmentation/BitFieldCoder.h>
+#include <DDSegmentation/Segmentation.h>
+#include <DDSegmentation/SegmentationParameter.h>
 
 #include <EVENT/LCCollection.h>
-#include <EVENT/MCParticle.h>
-#include <EVENT/SimTrackerHit.h>
+#include <EVENT/LCEvent.h>
+#include <EVENT/LCIO.h>
 #include <EVENT/SimCalorimeterHit.h>
-#include <EVENT/ReconstructedParticle.h>
-#include <EVENT/Track.h>
+#include <Exceptions.h>
 #include <UTIL/CellIDDecoder.h>
 
 // ----- include for verbosity dependend logging ---------
 #include <streamlog/loglevels.h>
 #include <streamlog/streamlog.h>
 
-#include <marlin/ProcessorEventSeeder.h>
-#include <marlin/Global.h>
-
-#include <TTree.h>
-#include <TFile.h>
-#include <TH2F.h>
-#include <TH1D.h>
-#include <TH2D.h>
-#include <TH3D.h>
+#include <RtypesCore.h>
 #include <TCanvas.h>
-#include <TStyle.h>
-#include <TLegend.h>
-#include <TRandom3.h>
-#include <TPaletteAxis.h>
 #include <TCrown.h>
+#include <TFile.h>
+#include <TH2.h>
+#include <TLegend.h>
+#include <TMath.h>
+#include <TString.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <TVirtualPad.h>
 
-#include <iostream>
 #include <iomanip>
-
+#include <iostream>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 using namespace lcio ;
 using namespace marlin ;
@@ -80,7 +78,6 @@ DrawBeamCalFromDD4hep::DrawBeamCalFromDD4hep() : Processor("DrawBeamCalFromDD4he
 			     m_nRun(0),
 			     m_nEvt(0),
 			     m_drawDensities(false),
-			     m_bcg(NULL),
 						 m_file(NULL),
 						 m_tree(NULL),
 						 m_x(0.0),

--- a/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
+++ b/source/MarlinProcessors/src/DrawBeamCalFromDD4hep.cpp
@@ -45,6 +45,8 @@
 using namespace lcio ;
 using namespace marlin ;
 
+// IWYU pragma: no_include <Math/GenVector/DisplacementVector3D.h>
+
 DrawBeamCalFromDD4hep aDrawBeamCalFromDD4hep;
 
 // #pragma GCC diagnostic push
@@ -70,24 +72,23 @@ int getColor(double energy, double minenergy=1e-3, double maxenergy=1e2) {
 
 }
 
-DrawBeamCalFromDD4hep::DrawBeamCalFromDD4hep() : Processor("DrawBeamCalFromDD4hep"),
-			     m_colNameBCal(""),
-			     m_nameOutputFile(""),
-			     m_nameFinalOutputFile(""),
-			     m_nameInputFile(""),
-			     m_nRun(0),
-			     m_nEvt(0),
-			     m_drawDensities(false),
-						 m_file(NULL),
-						 m_tree(NULL),
-						 m_x(0.0),
-						 m_y(0.0),
-						 m_z(0.0),
-						 m_energy(0.0)
+DrawBeamCalFromDD4hep::DrawBeamCalFromDD4hep()
+    : Processor("DrawBeamCalFromDD4hep"),
+      m_colNameBCal(""),
+      m_nameOutputFile(""),
+      m_nameFinalOutputFile(""),
+      m_nameInputFile(""),
+      m_nRun(0),
+      m_nEvt(0),
+      m_drawDensities(false),
+      m_file(nullptr),
+      m_tree(nullptr),
+      m_x(0.0),
+      m_y(0.0),
+      m_z(0.0),
+      m_energy(0.0)
 
-						 
 {
-
   // modify processor description
   _description = "DrawBeamCalFromDD4hep draws segmentation from dd4hep with energy deposits in the lcio files" ;
 
@@ -245,7 +246,7 @@ void DrawBeamCalFromDD4hep::end(){
   m_file->Write();
   m_file->Close();
   delete m_file;
-  m_file = NULL;
+  m_file = nullptr;
   streamlog_out ( MESSAGE ) << __PRETTY_FUNCTION__ << " " << name()
 			    << " processed " << m_nEvt << " events."
 			    << std::endl ;
@@ -394,8 +395,8 @@ void DrawBeamCalFromDD4hep::drawPolarGridRPhi2() {
     hitEDensities[cellid] = edensity;
   }
 
-  TCrown *tcmin = NULL;
-  TCrown *tcmax = NULL;
+  TCrown* tcmin = nullptr;
+  TCrown* tcmax = nullptr;
 
   for (auto ehit : hitEDensities) {
     unsigned int cellid = ehit.first;

--- a/source/MarlinProcessors/src/MarlinLumiCalClusterer.cc
+++ b/source/MarlinProcessors/src/MarlinLumiCalClusterer.cc
@@ -1,10 +1,15 @@
 #include "MarlinLumiCalClusterer.h"
 
 #include <EVENT/LCEvent.h>
+#include <EVENT/LCIO.h>
 
-#include <string>
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
+
+#include <iostream>
 #include <map>
-
+#include <string>
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 // GENERAL NOTES:

--- a/source/MarlinProcessors/src/MarlinLumiCalClusterer.cc
+++ b/source/MarlinProcessors/src/MarlinLumiCalClusterer.cc
@@ -1,12 +1,6 @@
-#include "Global.hh"
 #include "MarlinLumiCalClusterer.h"
 
 #include <EVENT/LCEvent.h>
-
-#include <gear/GEAR.h>
-#include <gear/GearParameters.h>
-#include <gear/CalorimeterParameters.h>
-#include <gear/LayerLayout.h>
 
 #include <string>
 #include <map>

--- a/source/MarlinProcessors/src/ReadBeamCal.cpp
+++ b/source/MarlinProcessors/src/ReadBeamCal.cpp
@@ -7,11 +7,17 @@
 #include "BeamCalGeo.hh"
 
 #include <EVENT/LCCollection.h>
+#include <EVENT/LCEvent.h>
+#include <EVENT/LCIO.h>
 #include <EVENT/SimCalorimeterHit.h>
 #include <UTIL/CellIDDecoder.h>
 
+#include <Exceptions.h>
+
 // ----- include for verbosity dependend logging ---------
+#include <streamlog/baselevels.h>
 #include <streamlog/loglevels.h>
+#include <streamlog/logstream.h>
 #include <streamlog/streamlog.h>
 
 #include <marlin/ProcessorEventSeeder.h>
@@ -24,9 +30,10 @@
 #include <TStyle.h>
 #include <TTree.h>
 
-#include <iostream>
 #include <iomanip>
-
+#include <iostream>
+#include <stdexcept>
+#include <vector>
 
 using namespace lcio ;
 using namespace marlin ;
@@ -36,20 +43,20 @@ ReadBeamCal aReadBeamCal ;
 // #pragma GCC diagnostic push
 // #pragma GCC diagnostic ignored "-Wshadow"
 
-ReadBeamCal::ReadBeamCal() : Processor("ReadBeamCal"),
-			     m_colNameBCal(""),
-			     m_nameOutputFile(""),
-			     m_nameFinalOutputFile(""),
-			     m_nameInputFile(""),
-			     m_nRun(0),
-			     m_nEvt(0),
-			     m_probFactor(0.0),
-			     m_random3(NULL),
-			     m_padEnergiesLeft(NULL),
-			     m_padEnergiesRight(NULL),
-			     m_bcg(NULL),
-                             m_usingDD4HEP(false) {
-
+ReadBeamCal::ReadBeamCal()
+    : Processor("ReadBeamCal"),
+      m_colNameBCal(""),
+      m_nameOutputFile(""),
+      m_nameFinalOutputFile(""),
+      m_nameInputFile(""),
+      m_nRun(0),
+      m_nEvt(0),
+      m_probFactor(0.0),
+      m_random3(nullptr),
+      m_padEnergiesLeft(nullptr),
+      m_padEnergiesRight(nullptr),
+      m_bcg(nullptr),
+      m_usingDD4HEP(false) {
   // modify processor description
   _description = "ReadBeamCal reads the simulation for the pairs and creates two std::vector<double> in a tree, which can then be used later on for Overlay, calculation of fluctiuations, etc." ;
 
@@ -160,7 +167,7 @@ void ReadBeamCal::end(){
   tree->Branch("vec_left",m_padEnergiesLeft->getEnergies());
   tree->Fill();
 
-  TFile *rootfile = TFile::Open((TString)m_nameOutputFile,"RECREATE");
+  TFile* rootfile = TFile::Open(m_nameOutputFile.c_str(), "RECREATE");
 
   // for(unsigned int k = 0; k < bgruns.size(); k++) {
   //   bgruns[k]->Write();
@@ -192,7 +199,7 @@ void ReadBeamCal::end(){
   rootfile->Write();
   rootfile->Close();
   delete rootfile;
-  rootfile=NULL;
+  rootfile = nullptr;
   delete m_random3;
   delete m_bcg;
 

--- a/source/MarlinProcessors/src/ReadBeamCal.cpp
+++ b/source/MarlinProcessors/src/ReadBeamCal.cpp
@@ -1,15 +1,13 @@
 #include "ReadBeamCal.hh"
 #include "ProcessorUtilities.hh"
 
-#include <BeamCal.hh>
-#include <BCUtilities.hh>
+#include "BCPadEnergies.hh"
+#include "BCUtilities.hh"
+#include "BeamCal.hh"
+#include "BeamCalGeo.hh"
 
 #include <EVENT/LCCollection.h>
-#include <EVENT/MCParticle.h>
-#include <EVENT/SimTrackerHit.h>
 #include <EVENT/SimCalorimeterHit.h>
-#include <EVENT/ReconstructedParticle.h>
-#include <EVENT/Track.h>
 #include <UTIL/CellIDDecoder.h>
 
 // ----- include for verbosity dependend logging ---------
@@ -19,17 +17,12 @@
 #include <marlin/ProcessorEventSeeder.h>
 #include <marlin/Global.h>
 
-#include <TTree.h>
-#include <TFile.h>
-#include <TH2F.h>
-#include <TH1D.h>
-#include <TH2D.h>
-#include <TH3D.h>
 #include <TCanvas.h>
-#include <TStyle.h>
-#include <TLegend.h>
+#include <TFile.h>
+#include <TH2.h>
 #include <TRandom3.h>
-#include <TPaletteAxis.h>
+#include <TStyle.h>
+#include <TTree.h>
 
 #include <iostream>
 #include <iomanip>

--- a/source/Tests/include/TestUtilities.hh
+++ b/source/Tests/include/TestUtilities.hh
@@ -11,7 +11,9 @@
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/ReconstructedParticleImpl.h>
 
+
 #include <streamlog/streamlog.h>
+#include <marlin/VerbosityLevels.h>
 
 #include <iomanip>
 #include <iostream>
@@ -144,13 +146,13 @@ void fillLumiCal(GlobalMethodsClass& gmc, HitMap& hits, int phiID, int direction
   expectedTheta /= weightSum;
 }
 
-void fillCollection(HitMap const& hits, LCCollectionVec* col){
+void fillCollection(HitMap const& hits, IMPL::LCCollectionVec* col){
   for (auto const& hitPair : hits ) {
     col->addElement(hitPair.second);
   }
 }
 
-void fillLumiCal(GlobalMethodsClass& gmc, LCCollectionVec* col, int phiID, int direction,
+void fillLumiCal(GlobalMethodsClass& gmc, IMPL::LCCollectionVec* col, int phiID, int direction,
                        double& expectedTheta) {
   HitMap hits;
   fillLumiCal(gmc, hits, phiID, direction, expectedTheta);

--- a/source/Tests/include/TestUtilities.hh
+++ b/source/Tests/include/TestUtilities.hh
@@ -11,13 +11,13 @@
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/ReconstructedParticleImpl.h>
 
-
 #include <streamlog/streamlog.h>
 #include <marlin/VerbosityLevels.h>
 
+#include <cstdlib>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
-#include <cmath>
 
 
 using HitMap = std::map<long long, IMPL::CalorimeterHitImpl*>;
@@ -286,7 +286,3 @@ void initLogLevels(){
 }
 
 #endif // TESTUTILITIES_HH
-
-
-
-

--- a/source/Tests/src/TestBeamCalReco.cpp
+++ b/source/Tests/src/TestBeamCalReco.cpp
@@ -1,15 +1,22 @@
-#include "TestMain.hh"
+#include "TestMain.hh"  // IWYU pragma: keep
 
 #include "BCPCuts.hh"
 #include "BCPadEnergies.hh"
 #include "BCUtilities.hh"
 #include "BeamCalCluster.hh"
+#include "BeamCalGeo.hh"
 #include "BeamCalGeoDD.hh"
 
 #include <DD4hep/Detector.h>
 
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
+
 #include <iomanip>
 #include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 /// Inject Energy into the beamcal vector

--- a/source/Tests/src/TestBeamCalReco.cpp
+++ b/source/Tests/src/TestBeamCalReco.cpp
@@ -3,10 +3,10 @@
 #include "BCPCuts.hh"
 #include "BCPadEnergies.hh"
 #include "BCUtilities.hh"
-#include "BeamCal.hh"
 #include "BeamCalCluster.hh"
 #include "BeamCalGeoDD.hh"
-#include "TestUtilities.hh"
+
+#include <DD4hep/Detector.h>
 
 #include <iomanip>
 #include <iostream>

--- a/source/Tests/src/TestLumi2Clu.cpp
+++ b/source/Tests/src/TestLumi2Clu.cpp
@@ -5,12 +5,9 @@
 #include "LumiCalClusterer.h"
 #include "TestUtilities.hh"
 
-#include <IMPL/CalorimeterHitImpl.h>
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCEventImpl.h>
 
-#include <algorithm>
-#include <cmath>
 #include <iostream>
 #include <vector>
 

--- a/source/Tests/src/TestLumi2Clu.cpp
+++ b/source/Tests/src/TestLumi2Clu.cpp
@@ -1,14 +1,24 @@
-#include "TestMain.hh"
+#include "TestMain.hh"  // IWYU pragma: keep
 
+#include "Global.hh"
 #include "GlobalMethodsClass.h"
 #include "LCCluster.hh"
 #include "LumiCalClusterer.h"
 #include "TestUtilities.hh"
 
+#include <EVENT/LCIO.h>
+#include <EVENT/LCParameters.h>
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCEventImpl.h>
 
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
+
+#include <iomanip>
 #include <iostream>
+#include <map>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 int runTest(int, char**) {

--- a/source/Tests/src/TestLumi2Clu.cpp
+++ b/source/Tests/src/TestLumi2Clu.cpp
@@ -41,8 +41,8 @@ int runTest(int, char**) {
       std::vector<double> expectedPhi{expectedPhi_1, expectedPhi_2};
       std::vector<double> expectedTheta(2, 0.0);  //filled later
       IMPL::LCEventImpl   myEvt;
-      auto*               col = new IMPL::LCCollectionVec(LCIO::CALORIMETERHIT);
-      col->parameters().setValue(LCIO::CellIDEncoding, "system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16");
+      auto*               col = new IMPL::LCCollectionVec(EVENT::LCIO::CALORIMETERHIT);
+      col->parameters().setValue(EVENT::LCIO::CellIDEncoding, "system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16");
       HitMap hits;
       fillLumiCal(gmc, hits, padIDToFill, directionID == -1 ? 2 : directionID, expectedTheta[0]);
       fillLumiCal(gmc, hits, padIDToFill + deltaPad, directionID == -1 ? 2 : directionID, expectedTheta[1], 20);

--- a/source/Tests/src/TestLumiCalReco.cpp
+++ b/source/Tests/src/TestLumiCalReco.cpp
@@ -1,13 +1,24 @@
-#include "TestMain.hh"
+#include "TestMain.hh"  // IWYU pragma: keep
+#include "TestUtilities.hh"
 
+#include "Global.hh"
 #include "GlobalMethodsClass.h"
 #include "LCCluster.hh"
 #include "LumiCalClusterer.h"
 
+#include <EVENT/LCIO.h>
+#include <EVENT/LCParameters.h>
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCEventImpl.h>
 
+#include <streamlog/loglevels.h>
+#include <streamlog/streamlog.h>
+
+#include <iomanip>
 #include <iostream>
+#include <map>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 int runTest(int, char**) {

--- a/source/Tests/src/TestLumiCalReco.cpp
+++ b/source/Tests/src/TestLumiCalReco.cpp
@@ -37,8 +37,8 @@ int runTest(int, char**) {
       auto              expectedPhi   = expectedPhis[counter++];
       double            expectedTheta = 0.0;  //filled later
       IMPL::LCEventImpl myEvt;
-      auto*             col = new IMPL::LCCollectionVec(LCIO::CALORIMETERHIT);
-      col->parameters().setValue(LCIO::CellIDEncoding, "system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16");
+      auto*             col = new IMPL::LCCollectionVec(EVENT::LCIO::CALORIMETERHIT);
+      col->parameters().setValue(EVENT::LCIO::CellIDEncoding, "system:8,barrel:3,layer:8,slice:8,r:32:-16,phi:-16");
       fillLumiCal(gmc, col, padIDToFill, directionID == -1 ? 2 : directionID, expectedTheta);
       myEvt.addCollection(col, "lumiCollection");
 

--- a/source/Tests/src/TestLumiCalReco.cpp
+++ b/source/Tests/src/TestLumiCalReco.cpp
@@ -4,11 +4,9 @@
 #include "LCCluster.hh"
 #include "LumiCalClusterer.h"
 
-#include <IMPL/CalorimeterHitImpl.h>
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCEventImpl.h>
 
-#include <cmath>
 #include <iostream>
 #include <vector>
 

--- a/source/Utilities/include/RootUtils.hh
+++ b/source/Utilities/include/RootUtils.hh
@@ -1,14 +1,14 @@
 #ifndef RootUtils_hh
 #define RootUtils_hh 1
 
-#include <TROOT.h>
+#include <RtypesCore.h>
 
 #include <vector>
 
-class TH1;
 class TEfficiency;
 class TGraph;
 class TGraphErrors;
+class TH1;
 
 
 namespace RootUtils {

--- a/source/Utilities/src/BCBackgroundPar.cpp
+++ b/source/Utilities/src/BCBackgroundPar.cpp
@@ -18,18 +18,19 @@
 *
 */
 
+#include "BackgroundFitter.hh"
 
+#include <TFile.h>
+#include <TTree.h>
+
+#include <stddef.h>
 #include <algorithm>
 #include <cmath>
-#include <vector>
 #include <iostream>
-#include <string>
+#include <memory>
 #include <numeric>
-
-#include "TTree.h"
-#include "TFile.h"
-
-#include "BackgroundFitter.hh"
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/source/Utilities/src/BackgroundFitter.cpp
+++ b/source/Utilities/src/BackgroundFitter.cpp
@@ -1,19 +1,16 @@
 #include "BackgroundFitter.hh"
 
+#include <TF1.h>
+#include <TFitResult.h>
+#include <TFitResultPtr.h>
+#include <TH1.h>
+#include <TTree.h>
+
+#include <stddef.h>
 #include <algorithm>
 #include <cmath>
-#include <vector>
-#include <iostream>
 #include <string>
-#include <numeric>
-
-#include "TCanvas.h"
-#include "TTree.h"
-#include "TF1.h"
-#include "TFile.h"
-#include "TH1F.h"
-#include "TFitResult.h"
-#include "TFitResultPtr.h"
+#include <vector>
 
 using namespace std;
 

--- a/source/Utilities/src/RootUtils.cpp
+++ b/source/Utilities/src/RootUtils.cpp
@@ -1,11 +1,11 @@
 #include "RootUtils.hh"
 
-#include <TGraphErrors.h>
-#include <TGraphAsymmErrors.h>
+#include <Rtypes.h>
 #include <TEfficiency.h>
 #include <TGraph.h>
+#include <TGraphAsymmErrors.h>
+#include <TGraphErrors.h>
 #include <TH1.h>
-
 
 namespace RootUtils {
 

--- a/source/src/DrawBeamCals.cpp
+++ b/source/src/DrawBeamCals.cpp
@@ -4,14 +4,21 @@
 #include "BCRootUtilities.hh"
 
 //GEAR
+#include <GEAR.h>
 #include <gearxml/GearXML.h>
 
 //ROOT
+#include <TCanvas.h>
 #include <TH2.h>
 #include <TStyle.h>
 
-#include <string>
+#include <cstdlib>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+class BeamCalGeo;
 
 namespace gear {
   class GearMgr;

--- a/source/src/DrawBeamCals.cpp
+++ b/source/src/DrawBeamCals.cpp
@@ -1,5 +1,3 @@
-#include "BeamCalGeo.hh"
-#include "BeamCalGeoGear.hh"
 #include "BeamCalGeoCached.hh"
 #include "BeamCal.hh"
 #include "BCPadEnergies.hh"
@@ -7,17 +5,17 @@
 
 //GEAR
 #include <gearxml/GearXML.h>
-#include <gear/GearMgr.h>
 
 //ROOT
-#include <TFile.h>
-#include <TTree.h>
-#include <TH2F.h>
+#include <TH2.h>
 #include <TStyle.h>
 
 #include <string>
 #include <iostream>
 
+namespace gear {
+  class GearMgr;
+}
 
 int drawBeamCals(int argn, char **argc) {
 

--- a/source/src/ReconstructBecas.cpp
+++ b/source/src/ReconstructBecas.cpp
@@ -1,25 +1,30 @@
 #include "BeamCal.hh"
 #include "BCPadEnergies.hh"
 #include "BeamCalGeoCached.hh"
-#include "BeamCalGeoGear.hh"
 #include "BeamCalCluster.hh"
 #include "BCPCuts.hh"
 #include "BCRootUtilities.hh"
 
 //GEAR
+#include <GEAR.h>
 #include <gearxml/GearXML.h>
-#include <gear/GearMgr.h>
 
 //ROOT
-#include <TFile.h>
-#include <TTree.h>
-#include <TH2F.h>
+#include <TCanvas.h>
+#include <TH2.h>
 #include <TStyle.h>
 
-#include <vector>
 #include <iostream>
-#include <iomanip>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
+
+class BeamCalGeo;
+
+namespace gear {
+  class GearMgr;
+}
 
 int reconstructBecas (int argn, char **argc) {
  


### PR DESCRIPTION

Also tested with gcc49

BEGINRELEASENOTES
- Cleanup includes with "Include what you use", remove unused ones, explicitly add all used ones
- Remove some pragma warnings for implemented features
- Replace NULL with nullptr
- Adapt to changes proposed in ilcsoft/LCIO#35, use LCIO namespaces

ENDRELEASENOTES