### PR TITLE
Sub energy

### DIFF
--- a/Tests/TestReconstruction.xml
+++ b/Tests/TestReconstruction.xml
@@ -82,6 +82,8 @@
     <parameter name="BackgroundMethod" type="string">Empty </parameter>
     <!--The Name of the Detector the reconstruction is for-->
     <parameter name="DetectorName" type="string">LumiCal </parameter>
+    <!--The ID where the SubClusterEnergy will be added: //LumiCal=3, BeamCal=5 in DDPFOCreator.hh-->
+    <parameter name="SubClusterEnergyID" type="int"> 3 </parameter>
     <!--The ID of the first layer of the detector BeamCal 1: LumiCal: 0-->
     <parameter name="DetectorStartingLayerID" type="int">0 </parameter>
     <!--Name of BeamCal Collection-->
@@ -139,6 +141,12 @@
     <!--BeamCalClusterReco reproduces the beamstrahlung background for a given number of bunch-crossings NumberOfBX and puts the signal hits from the lcio input file on top of that, and then clustering is attempted.-->
     <!--How to estimate background [Gaussian, Parametrised, Pregenerated, Averaged]-->
     <parameter name="BackgroundMethod" type="string">Empty </parameter>
+    <!--The Name of the Detector the reconstruction is for-->
+    <parameter name="DetectorName" type="string">BeamCal </parameter>
+    <!--The ID where the SubClusterEnergy will be added: //LumiCal=3, BeamCal=5 in DDPFOCreator.hh-->
+    <parameter name="SubClusterEnergyID" type="int"> 5 </parameter>
+    <!--The ID of the first layer of the detector BeamCal 1: LumiCal: 0-->
+    <parameter name="DetectorStartingLayerID" type="int">1 </parameter>
     <!--Name of BeamCal Collection-->
     <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">BeamCalCollection </parameter>
     <!--Name of the Reconstructed Cluster collection-->

--- a/Tests/TestReconstruction.xml
+++ b/Tests/TestReconstruction.xml
@@ -80,9 +80,13 @@
     <!--BeamCalClusterReco reproduces the beamstrahlung background for a given number of bunch-crossings NumberOfBX and puts the signal hits from the lcio input file on top of that, and then clustering is attempted.-->
     <!--How to estimate background [Gaussian, Parametrised, Pregenerated, Averaged, Empty]-->
     <parameter name="BackgroundMethod" type="string">Empty </parameter>
+    <!--The Name of the Detector the reconstruction is for-->
     <parameter name="DetectorName" type="string">LumiCal </parameter>
+    <!--The ID of the first layer of the detector BeamCal 1: LumiCal: 0-->
+    <parameter name="DetectorStartingLayerID" type="int">0 </parameter>
     <!--Name of BeamCal Collection-->
     <parameter name="BeamCalCollectionName" type="string" lcioInType="SimCalorimeterHit">LumiCalCollection</parameter>
+    <!--Collection of CalorimeterHits from the BeamCal,only created when input are SimCalorimeterHits-->
     <parameter name="BeamCalHitsOutCollection" type="string" lcioInType="SimCalorimeterHit">LumiCal_Hits</parameter>
     <!--Name of the Reconstructed Cluster collection-->
     <parameter name="RecoClusterCollectionname" type="string" lcioOutType="Cluster">LumiCalClusters </parameter>
@@ -92,7 +96,10 @@
     <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
     <!--Multiply deposit energy by this factor to account for sampling fraction-->
     <parameter name="LinearCalibrationFactor" type="double"> 82.377 </parameter>
+    <!--Weighting constant to use in logarithmic weighting of hits, if negative energy weighting is used-->
     <parameter name="LogWeightingConstant" type="double"> 6.1 </parameter>
+    <!--Maximum Distance between primary tower and neighbours to put into one cluster-->
+    <parameter name="MaxPadDistance" type="double">60 </parameter>
     <!--Number of Bunch Crossings of Background-->
     <parameter name="NumberOfBX" type="int"> 0 </parameter>
     <!--Flag to create the TEfficiency for fast tagging library-->
@@ -103,7 +110,7 @@
     <!-- <parameter name="Verbosity" type="string">WARNING </parameter> -->
     <!--Number of Event that should be printed to PDF File-->
     <parameter name="PrintThisEvent" type="int">-1 </parameter>
-
+    <!--Root Inputfile(s)-->
     <parameter name="InputFileBackgrounds" type="StringVec"> </parameter>
     <!--Rings from which onwards the outside Thresholds are used-->
     <parameter name="StartingRing" type="FloatVec">0.0 </parameter>

--- a/source/LumiCalReco/src/GlobalMethodsClass.cpp
+++ b/source/LumiCalReco/src/GlobalMethodsClass.cpp
@@ -469,7 +469,7 @@ std::tuple<ClusterImpl*, ReconstructedParticleImpl*> GlobalMethodsClass::getLCIO
 
   ReconstructedParticleImpl* particle = new ReconstructedParticleImpl;
   const float                mass     = 0.0;
-  const float                charge   = 1e+19;
+  const float                charge   = 0.0;
   particle->setMass(mass);
   particle->setCharge(charge);
   particle->setEnergy(clusterEnergy);

--- a/source/MarlinProcessors/include/BeamCalClusterReco.hh
+++ b/source/MarlinProcessors/include/BeamCalClusterReco.hh
@@ -138,6 +138,8 @@ private:
   std::string m_BCalRPColName;
   std::string m_EfficiencyFileName;
   std::string m_detectorName = "";
+  //LCAL_INDEX=3, BCAL_INDEX=5 in DDPFOCreator.hh
+  int m_subClusterEnergyID = 5;
 
   ///Creates the BeamCalGeometry either from DD4hep if compiled with DD4hep and
   ///the geometry is available or from GearFile in all other cases

--- a/source/MarlinProcessors/src/BeamCalClusterReco.cpp
+++ b/source/MarlinProcessors/src/BeamCalClusterReco.cpp
@@ -26,6 +26,7 @@
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCFlagImpl.h>
 #include <IMPL/ReconstructedParticleImpl.h>
+#include <LCIOSTLTypes.h>
 #include <UTIL/CellIDDecoder.h>
 
 // ----- include for verbosity dependent logging ---------
@@ -158,6 +159,10 @@ BeamCalClusterReco::BeamCalClusterReco()
 
   registerProcessorParameter("DetectorName", "The Name of the Detector the reconstruction is for",
                              m_detectorName, std::string("BeamCal"));
+
+  registerProcessorParameter("SubClusterEnergyID",
+                             "The ID where the SubClusterEnergy will be added: LumiCal=3, BeamCal=5 in DDPFOCreator.hh",
+                             m_subClusterEnergyID, m_subClusterEnergyID);
 
   registerProcessorParameter("DetectorStartingLayerID", "The ID of the first layer of the detector BeamCal 1: LumiCal: 0",
                              m_startingLayer, m_startingLayer);
@@ -417,7 +422,7 @@ void BeamCalClusterReco::processEvent( LCEvent * evt ) {
     const float phiCluster((*it)->getPhi()*TMath::DegToRad());
 
     const float mass = 0.0;
-    const float charge = 1e+19;
+    const float charge = 0.0;
     const float mmBeamCalDistance((*it)->getZ() / cos(thetaCluster));
 
 #pragma message "make sure rotation to labframe works on both sides and we are not rotating something weird"
@@ -445,7 +450,8 @@ void BeamCalClusterReco::processEvent( LCEvent * evt ) {
     for (auto const& hitID : (*it)->getClusterPads()) {
       cluster->addHit(m_caloHitMap[(*it)->getSide()][hitID.first], 1.0);
     }
-
+    cluster->subdetectorEnergies().resize(6);
+    cluster->subdetectorEnergies()[m_subClusterEnergyID] = energyCluster;
     ReconstructedParticleImpl* particle = new ReconstructedParticleImpl;
     particle->setMass( mass ) ;
     particle->setCharge( charge ) ;


### PR DESCRIPTION

BEGINRELEASENOTES
- BeamCalReco: fill subclusterEnergy to given ID via the ProcessorParameter: `SubClusterEnergyID`
- BeamCalReco/LumiCalReco: set charge to 0 so to not confuse the RecoMCTruth linker

ENDRELEASENOTES