### PR TITLE
Fix hits assigned to clusters

### DIFF
--- a/source/BeamCalReco/src/BeamCalBkgPregen.cpp
+++ b/source/BeamCalReco/src/BeamCalBkgPregen.cpp
@@ -13,7 +13,6 @@
 #include "BCPadEnergies.hh"
 #include "BeamCalBkg.hh"
 #include "BeamCalGeo.hh"
-#include "BeamCalGeoCached.hh"
 
 // ----- include for verbosity dependent logging ---------
 #include <streamlog/loglevels.h>
@@ -85,9 +84,6 @@ void BeamCalBkgPregen::init(vector<string> &bg_files, const int n_bx)
   m_backgroundBX->SetBranchAddress("vec_right", &m_BeamCalDepositsRight);
 
   streamlog_out(DEBUG2) << "We have " << m_backgroundBX->GetEntries() << " background BXs" << std::endl;
-
-  //Create an Average BeamCal, needed to setup the BCPadEnergies
-  m_BCG = new BeamCalGeoCached(marlin::Global::GEAR);
 
   m_BeamCalAverageLeft  =  new BCPadEnergies(m_BCG);
   m_BeamCalAverageRight =  new BCPadEnergies(m_BCG);

--- a/source/BeamCalReco/src/BeamCalGeoDD.cpp
+++ b/source/BeamCalReco/src/BeamCalGeoDD.cpp
@@ -22,8 +22,8 @@
 #include <vector>
 
 BeamCalGeoDD::BeamCalGeoDD(dd4hep::Detector const& theDetector, std::string const& detectorName,
-                           std::string const& colName): m_BeamCal(theDetector.detector(detectorName)),
-                                                                 m_segmentation(theDetector.readout(colName).segmentation()),
+                           std::string const& readoutName): m_BeamCal(theDetector.detector(detectorName)),
+                                                                 m_segmentation(theDetector.readout(readoutName).segmentation()),
                                                                  m_innerRadius(0.0),
                                                                  m_outerRadius(0.0),
                                                                  m_layers(0),

--- a/source/MarlinProcessors/include/BeamCalClusterReco.hh
+++ b/source/MarlinProcessors/include/BeamCalClusterReco.hh
@@ -79,6 +79,7 @@ class BeamCalClusterReco : public marlin::Processor {
   std::string m_colNameBCal;
   std::string m_bgMethodName;
   std::string m_hitsOutColName="BeamCal_Hits";
+  std::string m_readoutName="";
   std::vector<std::string> m_files;
 
   int m_nEvt ;

--- a/source/MarlinProcessors/include/ProcessorUtilities.hh
+++ b/source/MarlinProcessors/include/ProcessorUtilities.hh
@@ -19,7 +19,7 @@ namespace ProcessorUtilities {
   ///the geometry is available or from GearFile in all other cases
   inline BeamCalGeo* getBeamCalGeo(bool& usingDD4HEP,
                                    std::string const& detectorName="BeamCal",
-                                   std::string const& collectionName="BeamCalCollection") {
+                                   std::string const& readoutName="BeamCalCollection") {
 
 #ifdef FCAL_WITH_DD4HEP
     dd4hep::Detector& theDetector = dd4hep::Detector::getInstance();
@@ -28,7 +28,7 @@ namespace ProcessorUtilities {
       if (beamcal.isValid()){
 	streamlog_out(DEBUG) << "Creating DD4hep Based geometry" << std::endl;
 	usingDD4HEP = true;
-	return new BeamCalGeoDD(theDetector, detectorName, collectionName);
+	return new BeamCalGeoDD(theDetector, detectorName, readoutName);
       }
     } catch( std::runtime_error &e ) {
       streamlog_out(ERROR) << " Failed to created BeamCalGeometry from DD4hep: "

--- a/source/MarlinProcessors/src/BeamCalClusterReco.cpp
+++ b/source/MarlinProcessors/src/BeamCalClusterReco.cpp
@@ -1115,7 +1115,11 @@ LCCollection* BeamCalClusterReco::createCaloHitCollection(LCCollection* simCaloH
   auto caloHitCollection = new IMPL::LCCollectionVec(LCIO::CALORIMETERHIT);
   caloHitCollection->parameters().setValue(LCIO::CellIDEncoding,
                                            simCaloHitCollection->getParameters().getStringVal(LCIO::CellIDEncoding));
-  caloHitCollection->setFlag(simCaloHitCollection->getFlag());
+
+  IMPL::LCFlagImpl lcFlagImpl;
+  lcFlagImpl.setBit(LCIO::CHBIT_ID1);
+  lcFlagImpl.setBit(LCIO::CHBIT_LONG);
+  caloHitCollection->setFlag(lcFlagImpl.getFlag());
   for (int i = 0; i < simCaloHitCollection->getNumberOfElements(); ++i) {
     auto simHit = static_cast<EVENT::SimCalorimeterHit*>(simCaloHitCollection->getElementAt(i));
     auto calHit = new CalorimeterHitImpl();


### PR DESCRIPTION
BEGINRELEASENOTES
-  BeamCalClusterReco: fix problem when using CalorimeterHit collection as input
     * add optional parameter ReadoutName to be set in that case
- BeamCalClusterReco: fix setting of CalorimeterHit collection flags , fixes #49 , where the cluster was only having nullptrs when the collection was written out
- BeamCalClusterReco: only add hits to cluster if they don't come from background
- BeamCalClusterReco: Pregenerated background, remove explicit gear dependency 

ENDRELEASENOTES