### PR TITLE
MarlinLumiCalClusterer: always add collections to the event, even if …

### DIFF
--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -88,13 +88,8 @@ void MarlinLumiCalClusterer::TryMarlinLumiCalClusterer(EVENT::LCEvent* evt) {
     }
 
     //Add collections to the event if there are clusters
-    if (LCalClusterCol->getNumberOfElements() != 0) {
-      evt->addCollection(LCalClusterCol, LumiClusterColName);
-      evt->addCollection(LCalRPCol, LumiRecoParticleColName);
-    } else {
-      delete LCalClusterCol;
-      delete LCalRPCol;
-    }
+    evt->addCollection(LCalClusterCol, LumiClusterColName);
+    evt->addCollection(LCalRPCol, LumiRecoParticleColName);
 
     //Optionally write information to ROOT tree
     writeRootInfo(evt);


### PR DESCRIPTION
…empty



BEGINRELEASENOTES
- LumiCalReco: always write out collections, even if they are empty. Needed for EDM4hep compatibility, collections always have to be present

ENDRELEASENOTES