### PR TITLE
Always record the output collections, even if they are empty.

### DIFF
--- a/source/LumiCalReco/include/LumiCalClusterer.h
+++ b/source/LumiCalReco/include/LumiCalClusterer.h
@@ -25,6 +25,11 @@
 #include <string>
 #include <memory>
 
+enum RETVAL {
+  NOK = 0,
+  OK = 1,
+};
+
 namespace EVENT {
   class CalorimeterHit;
   class LCEvent;
@@ -45,7 +50,7 @@ public:
   void setCutOnFiducialVolume( bool cutFlag ) { _cutOnFiducialVolume = cutFlag; }
 
   // main actions in each event -Called for every event - the working horse.
-  int processEvent( EVENT::LCEvent * evt ) ;
+  RETVAL processEvent( EVENT::LCEvent * evt ) ;
 
   MapIntMapIntVInt       _superClusterIdToCellId;
   MapIntMapIntVDouble    _superClusterIdToCellEngy;

--- a/source/LumiCalReco/src/LumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/LumiCalClusterer.cpp
@@ -154,9 +154,7 @@ void LumiCalClustererClass::init( GlobalMethodsClass const& gmc ){
 /* ============================================================================
    main actions in each event:
    ========================================================================= */
-int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
-  int OK = 1;
-  int NOK = 0;
+RETVAL LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
   // increment / initialize global variables
   _totEngyArm[-1] = _totEngyArm[1] = 0.;
   _numHitsInArm[-1] = _numHitsInArm[1] = 0;
@@ -175,7 +173,7 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
      of IMPL::CalorimeterHitImpl. Hits are split in two std::vectors, one for each arm
      of LumiCal.
      -------------------------------------------------------------------------- */
-  if ( !getCalHits(evt , calHits) ) return NOK;
+  if ( !getCalHits(evt , calHits) ) return RETVAL::NOK;
 
 
   /* --------------------------------------------------------------------------
@@ -258,6 +256,6 @@ int LumiCalClustererClass::processEvent( EVENT::LCEvent * evt ) {
     }
   }
 
-  return OK;
+  return RETVAL::OK;
 
 }

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -57,8 +57,7 @@ void MarlinLumiCalClusterer::TryMarlinLumiCalClusterer(EVENT::LCEvent* evt) {
        create clusters using: LumiCalClustererClass
        -------------------------------------------------------------------------- */
 
-    if (!LumiCalClusterer.processEvent(evt))
-      return;
+    bool stat = LumiCalClusterer.processEvent(evt);
 
     LCCollectionVec* LCalClusterCol = new LCCollectionVec(LCIO::CLUSTER);
     IMPL::LCFlagImpl lcFlagImpl;
@@ -67,27 +66,29 @@ void MarlinLumiCalClusterer::TryMarlinLumiCalClusterer(EVENT::LCEvent* evt) {
 
     LCCollectionVec* LCalRPCol = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
 
-    streamlog_out(DEBUG6) << " Transfering reco results to LCalClusterCollection....." << std::endl;
+    if (stat) {
+      streamlog_out(DEBUG6) << " Transfering reco results to LCalClusterCollection....." << std::endl;
 
-    for (int armNow = -1; armNow < 2; armNow += 2) {
-      streamlog_out(DEBUG6) << " Arm  " << std::setw(4) << armNow
-                            << "\t Number of clusters: " << LumiCalClusterer._superClusterIdToCellId[armNow].size()
-                            << std::endl;
+      for (int armNow = -1; armNow < 2; armNow += 2) {
+        streamlog_out(DEBUG6) << " Arm  " << std::setw(4) << armNow
+                              << "\t Number of clusters: " << LumiCalClusterer._superClusterIdToCellId[armNow].size()
+                              << std::endl;
 
-      for (auto const& pairIDCells : LumiCalClusterer._superClusterIdToCellId[armNow]) {
-        const int  clusterId       = pairIDCells.first;
-        LCCluster& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
-        thisClusterInfo.recalculatePositionFromHits(gmc);
-        auto objectTuple(gmc.getLCIOObjects(thisClusterInfo, _minClusterEngy, _cutOnFiducialVolume));
-        if (std::get<0>(objectTuple) == nullptr)
-          continue;
+        for (auto const& pairIDCells : LumiCalClusterer._superClusterIdToCellId[armNow]) {
+          const int  clusterId       = pairIDCells.first;
+          LCCluster& thisClusterInfo = LumiCalClusterer._superClusterIdClusterInfo[armNow][clusterId];
+          thisClusterInfo.recalculatePositionFromHits(gmc);
+          auto objectTuple(gmc.getLCIOObjects(thisClusterInfo, _minClusterEngy, _cutOnFiducialVolume));
+          if (std::get<0>(objectTuple) == nullptr)
+            continue;
 
-        LCalClusterCol->addElement(std::get<0>(objectTuple));
-        LCalRPCol->addElement(std::get<1>(objectTuple));
+          LCalClusterCol->addElement(std::get<0>(objectTuple));
+          LCalRPCol->addElement(std::get<1>(objectTuple));
+        }
       }
     }
 
-    //Add collections to the event if there are clusters
+    //Add collections to the event
     evt->addCollection(LCalClusterCol, LumiClusterColName);
     evt->addCollection(LCalRPCol, LumiRecoParticleColName);
 

--- a/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
+++ b/source/LumiCalReco/src/MarlinLumiCalClusterer.cpp
@@ -57,7 +57,7 @@ void MarlinLumiCalClusterer::TryMarlinLumiCalClusterer(EVENT::LCEvent* evt) {
        create clusters using: LumiCalClustererClass
        -------------------------------------------------------------------------- */
 
-    bool stat = LumiCalClusterer.processEvent(evt);
+    RETVAL status = LumiCalClusterer.processEvent(evt);
 
     LCCollectionVec* LCalClusterCol = new LCCollectionVec(LCIO::CLUSTER);
     IMPL::LCFlagImpl lcFlagImpl;
@@ -66,7 +66,7 @@ void MarlinLumiCalClusterer::TryMarlinLumiCalClusterer(EVENT::LCEvent* evt) {
 
     LCCollectionVec* LCalRPCol = new LCCollectionVec(LCIO::RECONSTRUCTEDPARTICLE);
 
-    if (stat) {
+    if (status == RETVAL::OK) {
       streamlog_out(DEBUG6) << " Transfering reco results to LCalClusterCollection....." << std::endl;
 
       for (int armNow = -1; armNow < 2; armNow += 2) {


### PR DESCRIPTION
The output code decides what to write based on the contents of the first event.  If we don't always record the collections, then they can either be missing in the output, or we can get crashes when the output code tries to access a nonexistent collection.



BEGINRELEASENOTES
- Always record the output collection, even they are empty.  Avoids crashes from PodioOutput.
ENDRELEASENOTES